### PR TITLE
Add "Result" keyword for Rust

### DIFF
--- a/lang/rust.c
+++ b/lang/rust.c
@@ -39,7 +39,7 @@ static const char rust_keywords[] = {
 
 static const char rust_types[] = {
     "bool|char|i8|i16|i32|i64|isize|u8|u16|u32|u64|usize|f32|f64|str|"
-    "String|PathBuf|None|Option|Vec|List|Box|Cons|"
+    "String|PathBuf|None|Option|Result|Vec|List|Box|Cons|"
 };
 
 enum {


### PR DESCRIPTION
Hello,
Rust have a `Result` keyword which typically has two members `Ok(T)` and `Err(E)`. Since qemacs also highlights `Option` keyword highlighting `Result` seems reasonable as both are builtin in Rust.

 For more info: https://doc.rust-lang.org/std/result/index.html