### PR TITLE
Add commands `next-buffer` / `previous-buffer`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,8 +62,6 @@
   an EditBuffer could also have an embedded QECursor with no EditState
 * use hash tables for command and variable names
 * sort key binding tables?
-* `next-buffer` command on C-x C-right
-* `previous-buffer` command on C-x C-left
 * `save-some-buffers` command on C-x s
 * standardize key prefixes: C-, M-, S- and possibly others
 * use C-M- prefix instead of M-C- in source and documentation but support

--- a/qe.c
+++ b/qe.c
@@ -7442,12 +7442,20 @@ EditBuffer *next_non_system_buffer(EditState *s, EditBuffer *b) {
 
 void do_next_buffer(EditState *s)
 {
+    /* ignore command from the minibuffer and popups */
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
+        return;
+
     EditBuffer *b = next_non_system_buffer(s, s->b);
     switch_to_buffer(s, b);
 }
 
 void do_previous_buffer(EditState *s)
 {
+    /* ignore command from the minibuffer and popups */
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
+        return;
+
     /* what we want to compare & find are non-system buffers, so need to ignore
     all non-system buffer; or it may fall into an infinite loop. */
 

--- a/qe.c
+++ b/qe.c
@@ -7422,6 +7422,31 @@ void do_switch_to_buffer(EditState *s, const char *bufname)
         switch_to_buffer(s, b);
 }
 
+void do_next_buffer(EditState *s)
+{
+    EditBuffer *b = s->b->next;
+    if (b == NULL) {
+        b = s->qe_state->first_buffer;
+    }
+    switch_to_buffer(s, b);
+}
+
+void do_previous_buffer(EditState *s)
+{
+    EditBuffer *ob = s->b;
+    EditBuffer *nb = s->qe_state->first_buffer;
+    if (ob == nb) {
+        while (nb->next != NULL) {
+            nb = nb->next;
+        }
+    } else {
+        while (nb->next != ob) {
+            nb = nb->next;
+        }
+    }
+    switch_to_buffer(s, nb);
+}
+
 void do_toggle_read_only(EditState *s)
 {
     s->b->flags ^= BF_READONLY;

--- a/qeconfig.h
+++ b/qeconfig.h
@@ -224,6 +224,12 @@ static const CmdDef basic_commands[] = {
           do_kill_buffer, ESsi,
           "s{Kill buffer: }[buffer]|buffer|"
           "v", 0)
+    CMD0( "next-buffer", "C-x C-right",
+          "Switch to the next buffer",
+          do_next_buffer)
+    CMD0( "previous-buffer", "C-x C-left",
+          "Switch to the previous buffer",
+          do_previous_buffer)
     CMD0( "toggle-read-only", "C-x C-q, C-c %",
           "Toggle the read-only flag of the current buffer",
           do_toggle_read_only)


### PR DESCRIPTION
Sorry for the maybe imperfect solution (see notes below), but as a GNU Emacs user, I rely on commands `C-<right>` and `C-<left>` too, too, too, too, too heavily; nearly cannot live without these two commands inside an emacs environment and really cannot endure an editor without such feature, so I opened this PR at last.

# Some notes:
- I've already tried to follow the existing coding style as possible as I can (e.g. when `if (condition...)` + `return` in one line, should not use brackets.)
- I decided to skip all buffers of `BF_SYSTEM` because showing them is totally not useful in most cases. (And these buffers are still accessible via `bufed` if user really wants.)
  - **And I found an existing critical bug of `bufed`** when implementing: **if you switch into `*bufed*` buffer arbitrarily (via `*bufed*` itself) then press Enter will trigger `segmentation fault`.**
- I didn't implement universal argument because I never use it on these two commands... (*Something is better than nothing, after all*. We can implement it wait until someone really needs it...)
- Already tested some edge cases, for example:
    - Open `*bufed*` -> close `*bufed*` popup window (so that some system buffers are created) -> kill all non-system buffers -> trigger `next-buffer` / `previous-buffer` multiple times)
    - trigger  `next-buffer` / `previous-buffer` inside minibuffer / popup window.
