### PR TITLE
Add *equivalents* for `compare-windows`

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2279,6 +2279,18 @@ int eb_match_str_utf8(EditBuffer *b, int offset, const char *str, int *offsetp) 
     return 1;
 }
 
+int eb_match_str_utf8_reverse(EditBuffer *b, int offset, const char *str, int pos, int *offsetp) {
+    const char *p = str + pos;
+    while (p > str) {
+        char32_t c = utf8_decode_prev(&p, str);
+        if (eb_prevc(b, offset, &offset) != c)
+            return 0;
+    }
+    if (offsetp)
+        *offsetp = offset;
+    return 1;
+}
+
 int eb_match_istr_utf8(EditBuffer *b, int offset, const char *str, int *offsetp) {
     const char *p = str;
 

--- a/qe.c
+++ b/qe.c
@@ -6772,19 +6772,6 @@ void do_minibuffer_complete(EditState *s, int type, int key, int argval) {
     complete_end(&cs);
 }
 
-static int eb_match_string_reverse(EditBuffer *b, int offset, const char *str,
-                                   int *offsetp)
-{
-    int len = strlen(str);
-
-    while (len > 0) {
-        if (offset <= 0 || eb_prevc(b, offset, &offset) != (u8)str[--len])
-            return 0;
-    }
-    *offsetp = offset;
-    return 1;
-}
-
 static void do_minibuffer_electric_key(EditState *s, int key, int argval) {
     char32_t c;
     int offset, stop;
@@ -6798,9 +6785,9 @@ static void do_minibuffer_electric_key(EditState *s, int key, int argval) {
         c = eb_prevc(s->b, s->offset, &offset);
         if (c == '/') {
             /* kill leading part if typing a URL */
-            if (eb_match_string_reverse(s->b, offset, "http:", &stop)
-            ||  eb_match_string_reverse(s->b, offset, "https:", &stop)
-            ||  eb_match_string_reverse(s->b, offset, "ftp:", &stop)) {
+            if (eb_match_str_utf8_reverse(s->b, offset, "http:", 5, &stop)
+            ||  eb_match_str_utf8_reverse(s->b, offset, "https:", 6, &stop)
+            ||  eb_match_str_utf8_reverse(s->b, offset, "ftp:", 4, &stop)) {
                 /* nothing, stop already updated */
             }
             eb_delete(s->b, 0, stop);

--- a/qe.h
+++ b/qe.h
@@ -540,6 +540,7 @@ int eb_insert_char32_buf(EditBuffer *b, int offset, const char32_t *buf, int len
 int eb_insert_str(EditBuffer *b, int offset, const char *str);
 int eb_match_char32(EditBuffer *b, int offset, char32_t c, int *offsetp);
 int eb_match_str_utf8(EditBuffer *b, int offset, const char *str, int *offsetp);
+int eb_match_str_utf8_reverse(EditBuffer *b, int offset, const char *str, int pos, int *offsetp);
 int eb_match_istr_utf8(EditBuffer *b, int offset, const char *str, int *offsetp);
 /* These functions insert contents at b->offset */
 int eb_vprintf(EditBuffer *b, const char *fmt, va_list ap) qe__attr_printf(2,0);
@@ -993,6 +994,7 @@ struct QEmacsState {
     int ignore_comments;  /* ignore comments when comparing windows */
     int ignore_case;    /* ignore case when comparing windows */
     int ignore_preproc;    /* ignore preprocessor directives when comparing windows */
+    int ignore_equivalent;  /* ignore equivalent strings defined by `define-equivalent` */
     int hilite_region;  /* hilite the current region when selecting */
     int mmap_threshold; /* minimum file size for mmap */
     int max_load_size;  /* maximum file size for loading in memory */
@@ -1008,6 +1010,7 @@ struct QEmacsState {
     const char *user_option;
     int input_len;
     u8 input_buf[32];
+    struct Equivalent *first_equivalent;
 };
 
 extern QEmacsState qe_state;
@@ -1439,6 +1442,9 @@ void do_refresh_complete(EditState *s);
 void do_kill_buffer(EditState *s, const char *bufname, int force);
 void switch_to_buffer(EditState *s, EditBuffer *b);
 void qe_kill_buffer(EditBuffer *b);
+
+struct Equivalent *create_equivalent(const char *str1, const char *str2);
+void delete_equivalent(struct Equivalent *ep);
 
 /* text mode */
 

--- a/util.h
+++ b/util.h
@@ -263,6 +263,7 @@ int ustr_get_identifier_lc(char *buf, int buf_size, char32_t c,
 int ustr_match_keyword(const char32_t *buf, const char *str, int *lenp);
 int utf8_get_word(char *buf, int buf_size, char32_t c,
                   const char32_t *str, int i, int n);
+int utf8_prefix_len(const char *str1, const char *str2);
 
 static inline int check_fcall(const char32_t *str, int i) {
     while (str[i] == ' ')
@@ -596,6 +597,7 @@ static inline int utf8_is_trailing_byte(unsigned char c) {
 int utf8_encode(char *q, char32_t c);
 char32_t utf8_decode_strict(const char **pp);
 char32_t utf8_decode(const char **pp);
+char32_t utf8_decode_prev(const char **pp, const char *start);
 int utf8_to_char32(char32_t *dest, int dest_length, const char *str);
 int char32_to_utf8(char *dest, int dest_length, const char32_t *src, int src_length);
 

--- a/variables.c
+++ b/variables.c
@@ -66,6 +66,8 @@ static VarDef var_table[] = {
            "Set to ignore case in compare-windows." )
     S_VAR( "ignore-preproc", ignore_preproc, VAR_NUMBER, VAR_RW_SAVE,
            "Set to ignore preprocessing directives in compare-windows." )
+    S_VAR( "ignore-equivalent", ignore_equivalent, VAR_NUMBER, VAR_RW_SAVE,
+           "Set to ignore equivalent strings defined by define-equivalent." )
     S_VAR( "hilite-region", hilite_region, VAR_NUMBER, VAR_RW_SAVE,
            "Set to highlight the region after setting the mark." )
     S_VAR( "mmap-threshold", mmap_threshold, VAR_NUMBER, VAR_RW_SAVE,   // XXX: need set_value function


### PR DESCRIPTION
*equivalents* are strings that should compare equal in a `compare-windows` session. You can define such strings in a **.qerc** file in the directory of one of the files being compared.  This helps ignoring known changes such as type of function renaming... Here is an example to help compare files between the `bellard/quickjs` and the `quickjs-ng/quickjs` repositories:
```
define_equivalent("JS_DupValue(ctx, ", "js_dup(");
define_equivalent("JSValue", "JSValueConst");
define_equivalent("JS_NewInt32(ctx, ", "js_int32(");
define_equivalent("JS_NewInt32(ctx,\n", "js_int32(");
define_equivalent("JS_NewUint32(ctx, ", "js_uint32(");
define_equivalent("JS_NewUint32(ctx,\n", "js_uint32(");
define_equivalent("JS_NewBool(ctx, ", "js_bool(");
define_equivalent("JS_NewFloat64(ctx, ", "js_float64(");
define_equivalent("JS_EXTERN ", "");
define_equivalent("JS_EXTERN JS", "JS");
define_equivalent("JS_EXTERN JS_", "JS_");
ignore_equivalent = 1;
```
Other changes were necessary for proper utf8 skipping:
- add `utf8_prefix_len(str1, str2)` to compute the length of a common initial prefix not falling inside UTF-8 encoded codepoints.
- add `utf8_decode_prev` to get the previous codepoint
- add `eb_match_str_utf8_reverse`