### PR TITLE
Sundries

### DIFF
--- a/qe.h
+++ b/qe.h
@@ -267,7 +267,7 @@ typedef void (*ColorizeFunc)(QEColorizeContext *cp,
 /* buffer.c */
 
 /* begin to mmap files from this size */
-#define MIN_MMAP_SIZE  (2*1024*1024)
+#define MIN_MMAP_SIZE  (16*1024*1024)
 #define MAX_LOAD_SIZE  (512*1024*1024)
 
 #define MAX_PAGE_SIZE  4096

--- a/qescript.c
+++ b/qescript.c
@@ -1333,7 +1333,10 @@ static void qe_cfg_postprocess(EditState *s, QEmacsDataSource *ds, int argval) {
             break;
         case TOK_NUMBER:
             if (argval <= 0) {
-                put_status(s, "-> %lld  0x%llx", sp->u.value, sp->u.value);
+                len = snprintf(buf, sizeof buf, "-> %lld  0x%llx", sp->u.value, sp->u.value);
+                if (sp->u.value >= 32 && sp->u.value < 128)
+                    len += snprintf(buf + len, sizeof(buf) - len, "  '%c'", (int)sp->u.value);
+                put_status(s, "%s", buf);
             } else {
                 if (argval == 16)
                     len = snprintf(buf, sizeof buf, "0x%llx", sp->u.value);


### PR DESCRIPTION
- display character for `eval` results in range 32 to 127
- load files in memory up to 16MB