### PR TITLE
Add `repeat-mode`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,9 @@ else
 OBJS+= extras.o variables.o
 endif
 
-ifdef CONFIG_DARWIN
-  LDFLAGS += -L/opt/local/lib/
-endif
+#ifdef CONFIG_DARWIN
+#  LDFLAGS += -L/opt/local/lib/
+#endif
 
 ifdef CONFIG_PNG_OUTPUT
   HTMLTOPPM_LIBS += -lpng

--- a/buffer.c
+++ b/buffer.c
@@ -1235,6 +1235,7 @@ static void eb_addlog(EditBuffer *b, enum LogOperation op,
 
 void do_undo(EditState *s)
 {
+    QEmacsState *qs = s->qe_state;
     EditBuffer *b = s->b;
     int log_index, size_trailer;
     LogBuffer lb;
@@ -1264,6 +1265,13 @@ void do_undo(EditState *s)
     } else {
         put_status(s, "Undo!");
     }
+    if (!qs->first_transient_key
+    &&  (qs->last_key == 'u' || qs->last_key == 'u')) {
+        put_status(s, "repeat with 'u', 'r'");
+        qe_register_transient_binding(qs, "undo", "u");
+        qe_register_transient_binding(qs, "redo", "r");
+    }
+
     /* go backward */
     log_index -= sizeof(int);
     eb_read(b->log_buffer, log_index, &size_trailer, sizeof(int));

--- a/modes/bufed.c
+++ b/modes/bufed.c
@@ -293,12 +293,18 @@ static void bufed_select(EditState *s, int temp)
     if (e && b) {
         switch_to_buffer(e, b);
         e->last_buffer = last_buffer;
+    } else {
+        if (e == NULL) {
+            switch_to_buffer(s, b);
+        }
     }
     if (temp <= 0) {
-        /* delete bufed window */
-        do_delete_window(s, 1);
-        if (e)
-            e->qe_state->active_window = e;
+        if (s->flags & WF_POPUP) {
+            /* delete bufed window */
+            do_delete_window(s, 1);
+            if (e)
+                e->qe_state->active_window = e;
+        }
     } else {
         bs->last_index = index;
         do_refresh_complete(s);

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -3474,6 +3474,11 @@ static void do_next_error(EditState *s, int arg, int dir)
     do_find_file(s, fullpath, 0);
     do_goto_line(qs->active_window, line_num, col_num);
 
+    if (!qs->first_transient_key) {
+        qe_register_transient_binding(qs, "next-error", "M-n");
+        qe_register_transient_binding(qs, "previous-error", "M-p");
+    }
+
     put_status(s, "=> %s", error_message);
 }
 

--- a/qeconfig.h
+++ b/qeconfig.h
@@ -224,12 +224,12 @@ static const CmdDef basic_commands[] = {
           do_kill_buffer, ESsi,
           "s{Kill buffer: }[buffer]|buffer|"
           "v", 0)
-    CMD0( "next-buffer", "C-x C-right",
+    CMD3( "next-buffer", "C-x C-right",
           "Switch to the next buffer",
-          do_next_buffer)
-    CMD0( "previous-buffer", "C-x C-left",
+          do_buffer_navigation, ESii, "p" "v", 1)
+    CMD3( "previous-buffer", "C-x C-left",
           "Switch to the previous buffer",
-          do_previous_buffer)
+          do_buffer_navigation, ESii, "p" "v", -1)
     CMD0( "toggle-read-only", "C-x C-q, C-c %",
           "Toggle the read-only flag of the current buffer",
           do_toggle_read_only)
@@ -474,6 +474,9 @@ static const CmdDef basic_commands[] = {
     CMD0( "refresh", "C-l",
           "Refresh the display, center the window contents at point",
           do_refresh_complete)
+    CMD2( "repeat", "C-x z",
+          "Repeat last command with same prefix argument",
+          do_repeat, ESi, "p")
     CMD0( "undo", "C-x u, C-_, f9",
           "Undo the last change",
           do_undo)


### PR DESCRIPTION
- add `repeat` command on `C-x z`
- add `repeat-mode`, always enabled
- cycle all matching tags in current file on `goto-tag` and `find-tag`
- set up `repeat-mode` for these commands:
  - `undo` on `C-x u` (`u` repeats `undo`, `r` performs `redo`)
  - `undo` on `C-x r` (`r` repeats `redo`, `u` performs `undo`)
  - `find-window-left`, `find-window-right`, `find-window-up`, `find-window-dow` repeat navigation on `up`, `down`, `left`, `right`
  - `next-error`, `previous-error`: `M-n` and `M-p` repeat in corresponding direction
  - `next-buffer`, `previous-buffer: repeat buffers nagivation with `left` and `right`
  - `enlarge-window` / `shrink-window`: repeat resizing on `^`, `v`, `{`, `}` and cursor movement keys
  - `goto-tag` on `C-x ,` goto next tag with `,` and `.`
  - `call-last-kbd-macro` on `C-x e`: repeat macro on `e`
- add `eb_count_buffers` and `eb_get_buffer_from_index` for safe buffer navigation
- add transient bindings, known as repeat maps in GNU emacs
- pass `KeyDef **lp` (aka key maps) instead of mode for binding commands
- replace `do_next_buffer` and `do_prevous_buffer` with repeatable command `do_buffer_navigation`
- fix `bufed_select` crash bug when selecting buffer from a regular window