### PR TITLE
Fix `put_status`/`put_error` behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
       - name: build

--- a/Makefile
+++ b/Makefile
@@ -586,7 +586,8 @@ clean:
 	rm -rf *.dSYM *.gch .objs* .tobjs* .xobjs* bin
 	rm -f *~ *.o *.a *.exe *_g *_debug TAGS gmon.out core *.exe.stackdump \
            qe tqe tqe1 xqe kmaptoqe ligtoqe html2png cptoqe jistoqe \
-           fbftoqe fbffonts.c allmodules.txt basemodules.txt '.#'*[0-9]
+           fbftoqe fbffonts.c allmodules.txt basemodules.txt '.#'*[0-9] \
+           qe_asan qe_msan qe_ubsan
 
 distclean: clean
 	$(MAKE) -C libqhtml distclean

--- a/buffer.c
+++ b/buffer.c
@@ -1226,7 +1226,7 @@ void do_undo(EditState *s)
     LogBuffer lb;
 
     if (!b->log_buffer) {
-        put_status(s, "No undo information");
+        put_error(s, "No undo information");
         return;
     }
 
@@ -1246,14 +1246,14 @@ void do_undo(EditState *s)
         log_index = b->log_current - 1;
     }
     if (log_index == 0) {
-        put_status(s, "No further undo information");
+        put_error(s, "No further undo information");
         return;
     } else {
         put_status(s, "Undo!");
     }
     if (!qs->first_transient_key
     &&  (qs->last_key == 'u' || qs->last_key == 'u')) {
-        put_status(s, "repeat with 'u', 'r'");
+        put_status(s, "Repeat with 'u', 'r'");
         qe_register_transient_binding(qs, "undo", "u");
         qe_register_transient_binding(qs, "redo", "r");
     }
@@ -1311,7 +1311,7 @@ void do_redo(EditState *s)
     LogBuffer lb;
 
     if (!b->log_buffer) {
-        put_status(s, "No undo information");
+        put_error(s, "No undo information");
         return;
     }
 
@@ -1325,7 +1325,7 @@ void do_redo(EditState *s)
     }
 
     if (!b->log_current || !b->log_new_index) {
-        put_status(s, "Nothing to redo");
+        put_error(s, "Nothing to redo");
         return;
     }
     put_status(s, "Redo!");
@@ -2019,7 +2019,7 @@ int eb_raw_buffer_load1(EditBuffer *b, FILE *f, int offset)
     unsigned char buf[IOBUF_SIZE];
     int len, size, inserted;
 
-    //put_status(b->qs->active_window, "loading %s", filename);
+    //put_status(b->qs->active_window, "Loading %s", filename);
     size = inserted = 0;
     for (;;) {
         len = fread(buf, 1, IOBUF_SIZE, f);
@@ -2058,7 +2058,7 @@ int eb_mmap_buffer(EditBuffer *b, const char *filename)
     if (fd < 0)
         return -1;
     file_size = lseek(fd, 0, SEEK_END);
-    //put_status(b->qs->active_window, "mapping %s", filename);
+    //put_status(b->qs->active_window, "Mapping %s", filename);
     file_ptr = mmap(NULL, file_size, PROT_READ, MAP_SHARED, fd, 0);
     if ((void*)file_ptr == MAP_FAILED) {
         close(fd);
@@ -2130,7 +2130,7 @@ static int raw_buffer_save(EditBuffer *b, int start, int end,
     if (fd < 0)
         return -1;
 
-    //put_status(b->qs->active_window, "writing %s", filename);
+    //put_status(b->qs->active_window, "Writing %s", filename);
     if (end < start) {
         int tmp = start;
         start = end;

--- a/charset.c
+++ b/charset.c
@@ -23,7 +23,6 @@
  * THE SOFTWARE.
  */
 
-#include "util.h"
 #include "charset.h"
 
 /* XXX: Should move this to QEmacsState, and find a way for html2png */

--- a/display.h
+++ b/display.h
@@ -124,7 +124,7 @@ struct QEDisplay {
     void (*dpy_describe)(QEditScreen *s, struct EditBuffer *b);
     void (*dpy_sound_bell)(QEditScreen *s);
     void (*dpy_suspend)(QEditScreen *s);
-    void (*dpy_error)(QEditScreen *s, const char *fmt, ...);
+    void (*dpy_error)(QEditScreen *s, const char *fmt, ...) qe__attr_printf(2,3);
     QEDisplay *next;
 };
 

--- a/extras.c
+++ b/extras.c
@@ -388,11 +388,11 @@ void do_compare_files(EditState *s, const char *filename, int bflags)
         snprintf(buf, sizeof(buf), "../%s", filename);
     } else
     if (pathlen == 1) {
-        put_status(s, "Reference file is in root directory: %s", filename);
+        put_error(s, "Reference file is in root directory: %s", filename);
         return;
     } else
     if (pathlen >= MAX_FILENAME_SIZE) {
-        put_status(s, "Filename too long: %s", filename);
+        put_error(s, "Filename too long: %s", filename);
         return;
     } else {
         pstrcpy(buf, sizeof(buf), filename);
@@ -403,13 +403,11 @@ void do_compare_files(EditState *s, const char *filename, int bflags)
 
     // XXX: should check for regular file
     if (access(filename, R_OK)) {
-        put_status(s, "Cannot access file %s: %s",
-                   filename, strerror(errno));
+        put_error(s, "Cannot access file %s: %s", filename, strerror(errno));
         return;
     }
     if (access(buf, R_OK)) {
-        put_status(s, "Cannot access file %s: %s",
-                   buf, strerror(errno));
+        put_error(s, "Cannot access file %s: %s", buf, strerror(errno));
         return;
     }
 
@@ -443,7 +441,7 @@ static void do_adjust_window(EditState *s, int argval, int flags)
         argval = -argval;
 
     if (!qs->first_transient_key) {
-        put_status(s, "adjusting window, repeat with ^, }, {, v");
+        put_status(s, "Adjusting window, repeat with ^, }, {, v");
         qe_register_transient_binding(qs, "enlarge-window", "^, up");
         qe_register_transient_binding(qs, "shrink-window", "v, down");
         qe_register_transient_binding(qs, "enlarge-window-horizontally", "}, right");
@@ -748,7 +746,7 @@ static void do_indent_rigidly(EditState *s, int start, int end, int argval)
         QEmacsState *qs = s->qs;
         if (!qs->first_transient_key) {
             s->region_style = QE_STYLE_REGION_HILITE;
-            put_status(s, "indent the region interactively with TAB, left, right, S-left, S-right");
+            put_status(s, "Indent the region interactively with TAB, left, right, S-left, S-right");
             qe_register_transient_binding(qs, "indent-rigidly-left", "left");
             qe_register_transient_binding(qs, "indent-rigidly-right", "right");
             qe_register_transient_binding(qs, "indent-rigidly-left-to-tab-stop", "S-left, S-TAB");
@@ -924,8 +922,8 @@ static void forward_block(EditState *s, int dir)
                     --level;
                     if (level < MAX_LEVEL && balance[level] != c) {
                         /* XXX: should set mark and offset */
-                        put_status(s, "Unmatched delimiter %c <> %c",
-                                   c, balance[level]);
+                        put_error(s, "Unmatched delimiter %c <> %c",
+                                  c, balance[level]);
                         goto done;
                     }
                     if (level == 0) {
@@ -1008,8 +1006,8 @@ static void forward_block(EditState *s, int dir)
                     --level;
                     if (level < MAX_LEVEL && balance[level] != c) {
                         /* XXX: should set mark and offset */
-                        put_status(s, "Unmatched delimiter %c <> %c",
-                                   c, balance[level]);
+                        put_error(s, "Unmatched delimiter %c <> %c",
+                                  c, balance[level]);
                         goto done;
                     }
                     if (level == 0) {
@@ -1025,7 +1023,7 @@ static void forward_block(EditState *s, int dir)
     }
     if (level != 0) {
         /* XXX: should set mark and offset */
-        put_status(s, "Unmatched delimiter");
+        put_error(s, "Unmatched delimiter");
     } else {
         s->offset = offset;
     }
@@ -1220,7 +1218,7 @@ void do_show_bindings(EditState *s, const char *cmd_name)
     const CmdDef *d;
 
     if ((d = qe_find_cmd(qs, cmd_name)) == NULL) {
-        put_status(s, "No command %s", cmd_name);
+        put_error(s, "No command %s", cmd_name);
         return;
     }
     if (qe_list_bindings(qs, d, s->mode, 1, buf, sizeof(buf))) {
@@ -1236,7 +1234,7 @@ static void do_describe_function(EditState *s, const char *cmd_name) {
     const char *desc;
 
     if ((d = qe_find_cmd(s->qs, cmd_name)) == NULL) {
-        put_status(s, "No command %s", cmd_name);
+        put_error(s, "No command %s", cmd_name);
         return;
     }
     b = new_help_buffer(s);
@@ -1374,7 +1372,7 @@ void do_apropos(EditState *s, const char *str)
         show_popup(s, b, buf);
     } else {
         eb_free(&b);
-        put_status(s, "No apropos matches for `%s'", str);
+        put_error(s, "No apropos matches for `%s'", str);
     }
 }
 
@@ -1573,7 +1571,7 @@ static void do_set_style_color(EditState *e, const char *stylestr, const char *v
 
     stp = find_style(stylestr);
     if (!stp) {
-        put_status(e, "Unknown style '%s'", stylestr);
+        put_error(e, "Unknown style '%s'", stylestr);
         return;
     }
 
@@ -1582,7 +1580,7 @@ static void do_set_style_color(EditState *e, const char *stylestr, const char *v
     if (p > value) {
         pstrncpy(buf, sizeof buf, value, p - value);
         if (css_get_color(&stp->fg_color, buf)) {
-            put_status(e, "Unknown fgcolor '%s'", buf);
+            put_error(e, "Unknown fgcolor '%s'", buf);
             return;
         }
     }
@@ -1595,7 +1593,7 @@ static void do_set_style_color(EditState *e, const char *stylestr, const char *v
     qe_skip_spaces(&p);
     if (*p) {
         if (css_get_color(&stp->bg_color, p)) {
-            put_status(e, "Unknown bgcolor '%s'", p);
+            put_error(e, "Unknown bgcolor '%s'", p);
             return;
         }
     }
@@ -1611,7 +1609,7 @@ static void do_set_region_color(EditState *s, const char *str)
     s->region_style = 0;
 
     if (qe_term_get_style(str, &style)) {
-        put_status(s, "Invalid color '%s'", str);
+        put_error(s, "Invalid color '%s'", str);
         return;
     }
 
@@ -1656,7 +1654,7 @@ static void do_set_region_style(EditState *s, const char *str)
 
     st = find_style(str);
     if (!st) {
-        put_status(s, "Invalid style '%s'", str);
+        put_error(s, "Invalid style '%s'", str);
         return;
     }
     style = st - qe_styles;
@@ -2023,8 +2021,7 @@ static int chunk_cmp(void *vp0, const void *vp1, const void *vp2) {
 
     if ((++cp->ncmp & 8191) == 8191) {
         QEmacsState *qs = cp->b->qs;
-        put_status(qs->active_window, "Sorting: %d%%", (int)((cp->ncmp * 90LL) / cp->total_cmp));
-        dpy_flush(qs->screen);
+        put_status(qs->active_window, "&Sorting: %d%%", (int)((cp->ncmp * 90LL) / cp->total_cmp));
     }
     if (cp->flags & SF_REVERSE) {
         p1 = vp2;
@@ -2217,8 +2214,7 @@ static int eb_sort_span(EditBuffer *b, int *pp1, int *pp2, int cur_offset, int f
         // XXX: style issue. Should include newline from source buffer
         eb_putc(b1, '\n');
         if ((i & 8191) == 8191 && !(flags & SF_SILENT)) {
-            put_status(b->qs->active_window, "Sorting: %d%%", (int)(90 + i * 10LL / lines));
-            dpy_flush(b->qs->screen);
+            put_status(b->qs->active_window, "&Sorting: %d%%", (int)(90 + i * 10LL / lines));
         }
     }
     eb_delete_range(b, p1, p2);
@@ -2235,7 +2231,7 @@ done:
 static void do_sort_span(EditState *s, int p1, int p2, int argval, int flags) {
     s->region_style = 0;
     if (eb_sort_span(s->b, &p1, &p2, s->offset, flags | argval) < 0) {
-        put_status(s, "Out of memory");
+        put_error(s, "Out of memory");
         return;
     }
     s->b->mark = p1;
@@ -2339,7 +2335,7 @@ static void do_find_tag(EditState *s, const char *str) {
         s->offset = offset;
         return;
     }
-    put_status(s, "Tag not found: %s", str);
+    put_error(s, "Tag not found: %s", str);
 }
 
 static void do_goto_tag(EditState *s) {
@@ -2348,11 +2344,11 @@ static void do_goto_tag(EditState *s) {
 
     len = qe_get_word(s, buf, sizeof buf, s->offset, NULL);
     if (len >= sizeof(buf)) {
-        put_status(s, "Tag too large");
+        put_error(s, "Tag too large");
         return;
     } else
     if (len == 0) {
-        put_status(s, "No tag");
+        put_error(s, "No tag");
         return;
     } else {
         do_find_tag(s, buf);
@@ -2443,7 +2439,7 @@ static void charname_complete(CompleteState *cp, CompleteFunc enumerate) {
         }
         fclose(fp);
     } else {
-        put_status(cp->s, "cannot find DerivedName.txt or UnicodeData.txt in QEPATH");
+        put_error(cp->s, "Cannot find DerivedName.txt or UnicodeData.txt in QEPATH");
     }
 }
 

--- a/input.c
+++ b/input.c
@@ -111,7 +111,7 @@ void do_set_input_method(EditState *s, const char *name)
         s->input_method = m;
         s->selected_input_method = m;
     } else {
-        put_status(s, "'%s' not found", name);
+        put_error(s, "'%s' not found", name);
     }
 }
 

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -1304,7 +1304,7 @@ static void do_c_list_conditionals(EditState *s)
         show_popup(s, b, "Preprocessor conditionals");
     } else {
         eb_free(&b);
-        put_status(s, "Not in a #if conditional");
+        put_error(s, "Not in a #if conditional");
     }
     cp_destroy(cp);
 }

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -1438,7 +1438,7 @@ static EditState *dired_view_file(EditState *s, const char *filename)
 static void dired_execute(EditState *s)
 {
     /* Actually delete, copy, or move the marked items */
-    put_status(s, "Not yet implemented");
+    put_error(s, "Not yet implemented");
 }
 
 static void dired_parent(EditState *s, int collapse)
@@ -1527,7 +1527,7 @@ static void dired_toggle_dot_files(EditState *s, int val)
         dired_show_dot_files = val;
         if (ds)
             dired_update_buffer(ds, s->b, s, DIRED_UPDATE_FILTER);
-        put_status(s, "dot files are %s", val ? "visible" : "hidden");
+        put_status(s, "Dot files are %s", val ? "visible" : "hidden");
     }
 }
 
@@ -2017,7 +2017,7 @@ static void filelist_display_hook(EditState *s)
             }
             put_status(e, "Previewing %s", filename);
         } else {
-            put_status(s, "No access to %s", filename);
+            put_error(s, "No access to %s", filename);
         }
     }
 }

--- a/modes/fractal.c
+++ b/modes/fractal.c
@@ -659,7 +659,7 @@ static void fractal_set_parameters(EditState *s, FractalState *ms, const char *p
         } else
         if (strstart(p, "colors=", &p)) {
             if (!fractal_set_colors(ms, p, &p)) {
-                put_status(s, "invalid colors: %s", p);
+                put_error(s, "Invalid colors: %s", p);
                 p += strcspn(p, ", ");
             }
         } else
@@ -687,7 +687,7 @@ static void fractal_set_parameters(EditState *s, FractalState *ms, const char *p
         if (strstart(p, "y=", &p)) {
             ms->y = strtold_c(p, &p);
         } else {
-            put_status(s, "invalid parameter: %s", p);
+            put_error(s, "Invalid parameter: %s", p);
             break;
         }
     }

--- a/modes/image.c
+++ b/modes/image.c
@@ -231,7 +231,7 @@ static void image_set_size(EditState *s, int w, int h)
     ib = is->ibs->ib;
 
     if (w < 1 || h < 1) {
-        put_status(s, "Invalid image size");
+        put_error(s, "Invalid image size");
         return;
     }
 
@@ -737,8 +737,8 @@ static void image_rotate(EditState *e)
     if (ret < 0) {
         /* remove temporary image */
         image_free(ib1);
-        put_status(e, "Format '%s' not supported yet in rotate",
-                   avcodec_get_pix_fmt_name(pix_fmt));
+        put_error(e, "Format '%s' not supported yet in rotate",
+                  avcodec_get_pix_fmt_name(pix_fmt));
         return;
     }
     ib1->alpha_info = ib->alpha_info;
@@ -779,7 +779,7 @@ static void image_convert(EditState *e, const char *pix_fmt_str)
         if (strequal(name, pix_fmt_str))
             goto found;
     }
-    put_status(e, "Unknown pixel format");
+    put_error(e, "Unknown pixel format");
     return;
  found:
     new_pix_fmt = i;
@@ -791,9 +791,9 @@ static void image_convert(EditState *e, const char *pix_fmt_str)
     if (ret < 0) {
         /* remove temporary image */
         image_free(ib1);
-        put_status(e, "Conversion from '%s' to '%s' not supported yet",
-                   avcodec_get_pix_fmt_name(ib->pix_fmt),
-                   avcodec_get_pix_fmt_name(new_pix_fmt));
+        put_error(e, "Conversion from '%s' to '%s' not supported yet",
+                  avcodec_get_pix_fmt_name(ib->pix_fmt),
+                  avcodec_get_pix_fmt_name(new_pix_fmt));
         return;
     } else {
         char buf[128];

--- a/modes/latex-mode.c
+++ b/modes/latex-mode.c
@@ -245,7 +245,7 @@ static void latex_cmd_run(void *opaque, char *cmd,
     QEmacsState *qs = s->qs;
 
     if (cmd == NULL) {
-        put_status(s, "Aborted");
+        put_error(s, "Aborted");
         return;
     }
 
@@ -313,7 +313,7 @@ static void do_latex(EditState *e, const char *cmd)
             latex_cmd_run(func, buf, NULL);
         }
     } else {
-        put_status(e, "%s: No match", buf);
+        put_error(e, "%s: No match", buf);
     }
 }
 

--- a/modes/markdown.c
+++ b/modes/markdown.c
@@ -494,7 +494,7 @@ static int mkd_find_heading(EditState *s, int offset, int *level, int silent)
         offset = eb_prev_line(s->b, offset);
     }
     if (!silent)
-        put_status(s, "Before first heading");
+        put_error(s, "Before first heading");
 
     return -1;
 }
@@ -568,7 +568,7 @@ static void do_outline_up_heading(EditState *s)
         return;
 
     if (level <= 1) {
-        put_status(s, "Already at top level of the outline");
+        put_error(s, "Already at top level of the outline");
         return;
     }
 
@@ -585,7 +585,7 @@ static void do_mkd_backward_same_level(EditState *s)
 
     offset = mkd_prev_heading(s, offset, level, &level1);
     if (level1 != level) {
-        put_status(s, "No previous same-level heading");
+        put_error(s, "No previous same-level heading");
         return;
     }
     s->offset = offset;
@@ -601,7 +601,7 @@ static void do_mkd_forward_same_level(EditState *s)
 
     offset = mkd_next_heading(s, offset, level, &level1);
     if (level1 != level) {
-        put_status(s, "No following same-level heading");
+        put_error(s, "No following same-level heading");
         return;
     }
     s->offset = offset;
@@ -625,7 +625,7 @@ static void do_mkd_goto(EditState *s, const char *dest)
         for (; nb > 0; nb--) {
             offset = mkd_next_heading(s, offset, level, &level1);
             if (level != level1) {
-                put_status(s, "Heading not found");
+                put_error(s, "Heading not found");
                 return;
             }
         }
@@ -712,7 +712,7 @@ static void do_mkd_promote(EditState *s, int dir)
         if (level > 1)
             eb_delete_char32(s->b, offset);
         else
-            put_status(s, "Cannot promote to level 0");
+            put_error(s, "Cannot promote to level 0");
     }
 }
 
@@ -735,7 +735,7 @@ static void do_mkd_promote_subtree(EditState *s, int dir)
             if (level > 1) {
                 eb_delete_char32(s->b, offset);
             } else {
-                put_status(s, "Cannot promote to level 0");
+                put_error(s, "Cannot promote to level 0");
                 return;
             }
         }
@@ -754,7 +754,7 @@ static void do_mkd_move_subtree(EditState *s, int dir)
         return;
 
     if (!mkd_is_header_line(s, s->offset)) {
-        put_status(s, "Not on header line");
+        put_error(s, "Not on header line");
         return;
     }
 
@@ -768,12 +768,12 @@ static void do_mkd_move_subtree(EditState *s, int dir)
     if (dir < 0) {
         offset2 = mkd_prev_heading(s, offset, level, &level2);
         if (level2 < level) {
-            put_status(s, "Cannot move substree");
+            put_error(s, "Cannot move substree");
             return;
         }
     } else {
         if (offset1 == s->b->total_size || level1 < level) {
-            put_status(s, "Cannot move substree");
+            put_error(s, "Cannot move substree");
             return;
         }
         offset2 = mkd_next_heading(s, offset1, level, &level2);

--- a/modes/orgmode.c
+++ b/modes/orgmode.c
@@ -320,7 +320,7 @@ static int org_find_heading(EditState *s, int offset, int *level, int silent)
         offset = eb_prev_line(s->b, offset);
     }
     if (!silent)
-        put_status(s, "Before first heading");
+        put_error(s, "Before first heading");
 
     return -1;
 }
@@ -394,7 +394,7 @@ static void do_outline_up_heading(EditState *s)
         return;
 
     if (level <= 1) {
-        put_status(s, "Already at top level of the outline");
+        put_error(s, "Already at top level of the outline");
         return;
     }
 
@@ -411,7 +411,7 @@ static void do_org_backward_same_level(EditState *s)
 
     offset = org_prev_heading(s, offset, level, &level1);
     if (level1 != level) {
-        put_status(s, "No previous same-level heading");
+        put_error(s, "No previous same-level heading");
         return;
     }
     s->offset = offset;
@@ -427,7 +427,7 @@ static void do_org_forward_same_level(EditState *s)
 
     offset = org_next_heading(s, offset, level, &level1);
     if (level1 != level) {
-        put_status(s, "No following same-level heading");
+        put_error(s, "No following same-level heading");
         return;
     }
     s->offset = offset;
@@ -451,7 +451,7 @@ static void do_org_goto(EditState *s, const char *dest)
         for (; nb > 0; nb--) {
             offset = org_next_heading(s, offset, level, &level1);
             if (level != level1) {
-                put_status(s, "Heading not found");
+                put_error(s, "Heading not found");
                 return;
             }
         }
@@ -572,7 +572,7 @@ static void do_org_promote(EditState *s, int dir)
         if (level > 1)
             eb_delete_char32(s->b, offset);
         else
-            put_status(s, "Cannot promote to level 0");
+            put_error(s, "Cannot promote to level 0");
     }
 }
 
@@ -595,7 +595,7 @@ static void do_org_promote_subtree(EditState *s, int dir)
             if (level > 1) {
                 eb_delete_char32(s->b, offset);
             } else {
-                put_status(s, "Cannot promote to level 0");
+                put_error(s, "Cannot promote to level 0");
                 return;
             }
         }
@@ -614,7 +614,7 @@ static void do_org_move_subtree(EditState *s, int dir)
         return;
 
     if (!org_is_header_line(s, s->offset)) {
-        put_status(s, "Not on header line");
+        put_error(s, "Not on header line");
         return;
     }
 
@@ -628,12 +628,12 @@ static void do_org_move_subtree(EditState *s, int dir)
     if (dir < 0) {
         offset2 = org_prev_heading(s, offset, level, &level2);
         if (level2 < level) {
-            put_status(s, "Cannot move substree");
+            put_error(s, "Cannot move substree");
             return;
         }
     } else {
         if (offset1 == s->b->total_size || level1 < level) {
-            put_status(s, "Cannot move substree");
+            put_error(s, "Cannot move substree");
             return;
         }
         offset2 = org_next_heading(s, offset1, level, &level2);

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -204,8 +204,8 @@ static int run_process(ShellState *s,
 
     pty_fd = get_pty(tty_name, sizeof(tty_name));
     if (pty_fd < 0) {
-        put_status(s->b->qs->active_window, "run_process: cannot get tty: %s",
-                   strerror(errno));
+        put_error(s->b->qs->active_window, "run_process: cannot get tty: %s",
+                  strerror(errno));
         return -1;
     }
     fcntl(pty_fd, F_SETFL, O_NONBLOCK);
@@ -219,7 +219,7 @@ static int run_process(ShellState *s,
 
     pid = fork();
     if (pid < 0) {
-        put_status(s->b->qs->active_window, "run_process: cannot fork");
+        put_error(s->b->qs->active_window, "run_process: cannot fork");
         return -1;
     }
     if (pid == 0) {
@@ -2439,7 +2439,6 @@ static void shell_read_cb(void *opaque)
 
     /* now we do some refresh (should just invalidate?) */
     qe_display(qs);
-    dpy_flush(qs->screen);
 }
 
 static void shell_mode_free(EditBuffer *b, void *state)
@@ -2558,7 +2557,6 @@ static void shell_pid_cb(void *opaque, int status)
         qe_free_mode_data(&s->base);
     }
     qe_display(qs);
-    dpy_flush(qs->screen);
 }
 
 EditBuffer *qe_new_shell_buffer(QEmacsState *qs, EditBuffer *b0, EditState *e,
@@ -3158,7 +3156,7 @@ static void do_shell_yank(EditState *e)
 
         if (b) {
             if (b->total_size > 1024) {
-                put_status(e, "too much data to yank at shell prompt");
+                put_error(e, "Too much data to yank at shell prompt");
                 return;
             }
             for (offset = 0; offset < b->total_size;) {
@@ -3241,7 +3239,7 @@ static void do_shell_refresh(EditState *e, int flags)
     if (flags & SR_REFRESH)
         do_refresh_complete(e);
     if (s && !(flags & SR_SILENT)) {
-        put_status(e, "terminal size set to %d by %d", s->cols, s->rows);
+        put_status(e, "Terminal size set to %d by %d", s->cols, s->rows);
     }
 }
 
@@ -3415,7 +3413,7 @@ static void do_next_error(EditState *s, int arg, int dir)
         if ((b = qe_find_buffer_name(qs, "*compilation*")) == NULL
         &&  (b = qe_find_buffer_name(qs, "*shell*")) == NULL
         &&  (b = qe_find_buffer_name(qs, "*errors*")) == NULL) {
-            put_status(s, "No compilation buffer");
+            put_error(s, "No compilation buffer");
             return;
         }
         set_error_offset(b, -1);
@@ -3429,12 +3427,12 @@ static void do_next_error(EditState *s, int arg, int dir)
         if (dir > 0) {
             offset = eb_next_line(b, offset);
             if (offset >= b->total_size) {
-                put_status(s, "No more errors");
+                put_error(s, "No more errors");
                 return;
             }
         } else {
             if (offset <= 0) {
-                put_status(s, "No previous error");
+                put_error(s, "No previous error");
                 return;
             }
             offset = eb_prev_line(b, offset);

--- a/modes/stb.c
+++ b/modes/stb.c
@@ -133,7 +133,7 @@ static void image_display_hook(EditState *s) {
             ms->pic.data[0] = ms->stb_image;
             ms->pic.linesize[0] = ms->stb_x * 4;
         } else {
-            put_status(s, "stbi_load error");
+            put_error(s, "stbi_load error");
         }
     }
     edit_invalidate(s, 1);

--- a/modes/video.c
+++ b/modes/video.c
@@ -244,7 +244,6 @@ static void video_refresh_timer(void *opaque)
 
             /* display picture */
             qe_display(qs);
-            dpy_flush(qs->screen);
 
             /* update queue size and signal for next picture */
             if (++is->pictq_rindex == VIDEO_PICTURE_QUEUE_SIZE)
@@ -268,7 +267,6 @@ static void video_refresh_timer(void *opaque)
 
         /* display picture */
         qe_display(qs);
-        dpy_flush(qs->screen);
     } else {
         is->video_timer = qe_add_timer(100, s, video_refresh_timer);
     }
@@ -965,8 +963,8 @@ static void av_cycle_stream(EditState *s, int codec_type)
         start_index = is->audio_stream;
 
     if (start_index < 0) {
-        put_status(s, "No %s stream to cycle",
-                   (codec_type == CODEC_TYPE_VIDEO) ? "video" : "audio");
+        put_error(s, "No %s stream to cycle",
+                  (codec_type == CODEC_TYPE_VIDEO) ? "video" : "audio");
         return;
     }
 
@@ -975,8 +973,8 @@ static void av_cycle_stream(EditState *s, int codec_type)
         if (++stream_index >= ic->nb_streams)
             stream_index = 0;
         if (stream_index == start_index) {
-            put_status(s, "Only one %s stream",
-                       (codec_type == CODEC_TYPE_VIDEO) ? "video" : "audio");
+            put_error(s, "Only one %s stream",
+                      (codec_type == CODEC_TYPE_VIDEO) ? "video" : "audio");
             return;
         }
         st = ic->streams[stream_index];

--- a/qe.h
+++ b/qe.h
@@ -1625,9 +1625,6 @@ void do_mark_region(EditState *s, int mark, int offset);
 void do_changecase_word(EditState *s, int up);
 void do_changecase_region(EditState *s, int up);
 void do_delete_word(EditState *s, int dir);
-int cursor_func(DisplayState *ds,
-                int offset1, int offset2, int line_num,
-                int x, int y, int w, int h, int hex_mode);
 // should take argval
 void do_scroll_left_right(EditState *s, int n);
 void do_scroll_up_down(EditState *s, int dir);

--- a/qescript.c
+++ b/qescript.c
@@ -1413,7 +1413,7 @@ static int do_eval_buffer_region(EditState *s, int start, int stop, int argval) 
     /* extract region as UTF-8 with a size limit */
     length = eb_get_region_content_size(s->b, start, stop);
     if (length > MAX_SCRIPT_LENGTH || !(buf = qe_malloc_array(char, length + 1))) {
-        put_error(s, "buffer region too large");
+        put_error(s, "Buffer region too large");
         return -1;
     }
     length = eb_get_region_contents(s->b, start, stop, buf, length + 1, 0);
@@ -1454,7 +1454,7 @@ int parse_config_file(EditState *s, const char *filename) {
     ds.allocated_buf = file_load(filename, MAX_SCRIPT_LENGTH + 1, NULL);
     if (!ds.allocated_buf) {
         if (errno == ERANGE || errno == ENOMEM) {
-            put_error(s, "file too large");
+            put_error(s, "File too large");
         }
         return -1;
     }

--- a/unix.c
+++ b/unix.c
@@ -332,7 +332,6 @@ void url_main_loop(void (*init)(void *opaque), void *opaque)
             //qs->complete_refresh = 1;
             do_refresh(qs->first_window);
             qe_display(qs);
-            dpy_flush(qs->screen);
             url_display_request = 0;
         }
     }

--- a/variables.c
+++ b/variables.c
@@ -399,7 +399,7 @@ void do_show_variable(EditState *s, const char *name)
     char buf[MAX_FILENAME_SIZE];
 
     if (qe_get_variable(s, name, buf, sizeof(buf), NULL, 1) == VAR_UNKNOWN)
-        put_status(s, "No variable %s", name);
+        put_error(s, "No variable %s", name);
     else
         put_status(s, "%s -> %s", name, buf);
 }
@@ -408,13 +408,13 @@ void do_set_variable(EditState *s, const char *name, const char *value)
 {
     switch (qe_set_variable(s, name, value, 0)) {
     case VAR_UNKNOWN:
-        put_status(s, "Variable %s is invalid", name);
+        put_error(s, "Variable %s is invalid", name);
         break;
     case VAR_READONLY:
-        put_status(s, "Variable %s is read-only", name);
+        put_error(s, "Variable %s is read-only", name);
         break;
     case VAR_INVALID:
-        put_status(s, "Invalid value for variable %s: %s", name, value);
+        put_error(s, "Invalid value for variable %s: %s", name, value);
         break;
     default:
         do_show_variable(s, name);
@@ -427,7 +427,7 @@ static void do_describe_variable(EditState *s, const char *name) {
     VarDef *vp;
 
     if ((vp = qe_find_variable(s->qs, name)) == NULL) {
-        put_status(s, "No variable %s", name);
+        put_error(s, "No variable %s", name);
         return;
     }
     b = new_help_buffer(s);


### PR DESCRIPTION
- use `put_error` instead of `put_status` for command errors
- prevent status message output to console during initialization
- use `put_error` for side effects in command errors
- add `&` prefix in status messages to force screen flush
- flush screen in `qe_display()`, remove redundant calls to `dpy_flush`
- fix gcc compilation errors and warnings
- remove most references to `global_screen`
- free font cache before closing the screen
- prevent mouse handling upon focus detection