### PR TITLE
Fix asan crash bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,24 +97,24 @@ $(info Building with ASan)
 DEBUG_SUFFIX:=_asan
 ECHO_CFLAGS += -DCONFIG_ASAN
 CFLAGS += -D__ASAN__
-CFLAGS += -fsanitize=address $(SANITIZE_CFLAGS)
-LDFLAGS += -fsanitize=address $(SANITIZE_CFLAGS)
+CFLAGS += -fsanitize=address $(SANITIZE_CFLAGS) -g
+LDFLAGS += -fsanitize=address $(SANITIZE_CFLAGS) -g
 endif
 ifdef MSAN
 $(info Building with MSan)
 DEBUG_SUFFIX:=_msan
 ECHO_CFLAGS += -DCONFIG_MSAN
 CFLAGS += -D__MSAN__
-CFLAGS += -fsanitize=memory $(SANITIZE_CFLAGS)
-LDFLAGS += -fsanitize=memory $(SANITIZE_CFLAGS)
+CFLAGS += -fsanitize=memory $(SANITIZE_CFLAGS) -g
+LDFLAGS += -fsanitize=memory $(SANITIZE_CFLAGS) -g
 endif
 ifdef UBSAN
 $(info Building with UBSan)
 DEBUG_SUFFIX:=_ubsan
 ECHO_CFLAGS += -DCONFIG_UBSAN
 CFLAGS += -D__UBSAN__
-CFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS)
-LDFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS)
+CFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS) -g
+LDFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS) -g
 endif
 
 TARGETLIBS:=

--- a/qe.c
+++ b/qe.c
@@ -1850,7 +1850,7 @@ void do_combine_accent(EditState *s, int accent_arg) {
      ||  (combine_accent(g, c, accent)))
     &&  (len = eb_encode_char32(s->b, buf, g[0])) > 0) {
         /* if accent can be removed from previous ligature
-           or if previous character can be combined with accent into a
+           or if previous character can be combined with accent as a
            ligature, encode the single character and replace the
            previous character.
            XXX: should bypass eb_encode_char32 to detect encoding failure

--- a/util.c
+++ b/util.c
@@ -2713,7 +2713,7 @@ void qe_qsort_r(void *base, size_t nmemb, size_t size, void *thunk,
 #include "wcwidth.c"
 
 #ifdef CONFIG_TINY
-char32_t qe_unaccent(char32_t c) { return c; }
+char32_t qe_wcunaccent(char32_t c) { return c; }
 char32_t qe_wctolower(char32_t c) { return qe_tolower(c); }
 char32_t qe_wctoupper(char32_t c) { return qe_toupper(c); }
 #endif

--- a/util.h
+++ b/util.h
@@ -818,6 +818,7 @@ int is_shift_key(int key);
 
 #include "wcwidth.h"
 
+extern char32_t qe_wcunaccent(char32_t c);
 extern char32_t qe_wctoupper(char32_t c);
 extern char32_t qe_wctolower(char32_t c);
 
@@ -834,7 +835,9 @@ char32_t utf8_decode_prev(const char **pp, const char *start);
 int utf8_to_char32(char32_t *dest, int dest_length, const char *str);
 int char32_to_utf8(char *dest, int dest_length, const char32_t *src, int src_length);
 
-char32_t qe_unaccent(char32_t c);
+static inline char32_t qe_unaccent(char32_t c) {
+    return c >= 0x80 ? qe_wcunaccent(c) : c;
+}
 
 static inline int qe_isaccent(char32_t c) {
     return c >= 0x300 && qe_wcwidth(c) == 0;
@@ -857,13 +860,11 @@ static inline char32_t qe_iswupper(char32_t c) {
 }
 
 static inline char32_t qe_wtolower(char32_t c) {
-    return (qe_inrange(c, 'A', 'Z') ? c + 'a' - 'A' :
-            c >= 0x80 ? qe_wctolower(c) : c);
+    return c >= 0x80 ? qe_wctolower(c) : qe_tolower(c);
 }
 
 static inline char32_t qe_wtoupper(char32_t c) {
-    return (qe_inrange(c, 'a', 'z') ? c + 'A' - 'a' :
-            c >= 0x80 ? qe_wctoupper(c) : c);
+    return c >= 0x80 ? qe_wctoupper(c) : qe_toupper(c);
 }
 
 /*---- Completion types used for enumerations ----*/


### PR DESCRIPTION
- add debug info in asan, msan and ubsan builds
- avoid function call in `qe_unaccent` for ASCII chars
- fix `find_ligature` return type to detect simple ligatures with a simple test
- fix crash bug in `expand_ligature`, behavior was bogus anyway.