### PR TITLE
Improve error reporting

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -94,7 +94,7 @@ static void do_list_equivalents(EditState *s, int argval)
     show_popup(s, b, "Equivalents");
 }
 
-static void qe_free_equivalent(QEmacsState *qs) {
+static void qe_free_equivalents(QEmacsState *qs) {
     while (qs->first_equivalent) {
         Equivalent *ep = qs->first_equivalent;
         qs->first_equivalent = ep->next;
@@ -3354,7 +3354,7 @@ static int extras_init(QEmacsState *qs) {
 }
 
 static void extras_exit(QEmacsState *qs) {
-    qe_free_equivalent(qs);
+    qe_free_equivalents(qs);
 }
 
 qe_module_init(extras_init);

--- a/libqhtml/cssparse.c
+++ b/libqhtml/cssparse.c
@@ -72,6 +72,7 @@ static int css_get_length(int *length_ptr, int *unit_ptr, const char *p)
     char buf[32];
     double f;
 
+    // FIXME: use strtod directly
     p1 = p;
     if (*p == '+' || *p == '-')
         p++;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2572,8 +2572,10 @@ EditBuffer *qe_new_shell_buffer(QEmacsState *qs, EditBuffer *b0, EditState *e,
     if (!b0 && (shell_flags & SF_REUSE_BUFFER)) {
         b0 = qe_find_buffer_name(qs, bufname);
         if (b0) {
-            if (shell_flags & SF_ERASE_BUFFER)
+            if (shell_flags & SF_ERASE_BUFFER) {
+                /* XXX: this also clears the undo records */
                 eb_clear(b0);
+            }
         }
     }
 

--- a/qe.h
+++ b/qe.h
@@ -125,7 +125,7 @@ typedef struct QEArgs {
 } QEArgs;
 
 /* main loop for Unix programs using liburlio */
-void url_main_loop(void (*init)(void *opaque), void *opaque);
+int url_main_loop(int (*init)(void *opaque), void *opaque);
 
 int get_clock_ms(void);
 int get_clock_usec(void);
@@ -493,7 +493,7 @@ void qe_trace_bytes(QEmacsState *qs, const void *buf, int size, int state);
 void qe_data_init(QEmacsState *qs);
 
 EditBuffer *qe_find_buffer_name(QEmacsState *qs, const char *name);
-EditBuffer *qe_find_buffer_file(QEmacsState *qs, const char *filename);
+EditBuffer *qe_find_buffer_filename(QEmacsState *qs, const char *filename);
 EditBuffer *qe_new_buffer(QEmacsState *qs, const char *name, int flags);
 void eb_clear(EditBuffer *b);
 void eb_free(EditBuffer **ep);
@@ -1493,8 +1493,8 @@ void compute_client_area(EditState *s);
 
 /* window handling */
 void edit_close(EditState **sp);
-EditState *edit_new(EditBuffer *b,
-                    int x1, int y1, int width, int height, int flags);
+EditState *qe_new_window(EditBuffer *b,
+                         int x1, int y1, int width, int height, int flags);
 EditBuffer *qe_check_buffer(QEmacsState *qs, EditBuffer **sp);
 EditState *qe_check_window(QEmacsState *qs, EditState **sp);
 void qe_kill_buffer(QEmacsState *qs, EditBuffer *b);
@@ -1639,8 +1639,7 @@ void do_mark_whole_buffer(EditState *s);
 void do_yank(EditState *s);
 void do_yank_pop(EditState *s);
 void do_exchange_point_and_mark(EditState *s);
-QECharset *read_charset(EditState *s, const char *charset_str,
-                        EOLType *eol_typep);
+QECharset *qe_parse_charset(EditState *s, const char *charset_str, EOLType *eol_typep);
 void do_show_coding_system(EditState *s);
 void do_set_auto_coding(EditState *s, int verbose);
 void do_set_buffer_file_coding_system(EditState *s, const char *charset_str);

--- a/unix.c
+++ b/unix.c
@@ -317,11 +317,12 @@ static void url_block(void)
 #endif
 }
 
-void url_main_loop(void (*init)(void *opaque), void *opaque)
+int url_main_loop(int (*init)(void *opaque), void *opaque)
 {
     QEArgs *ap = opaque;
     url_block_reset();
-    (*init)(opaque);
+    if ((*init)(opaque))
+        return 1;
     for (;;) {
         if (url_exit_request)
             break;
@@ -335,6 +336,7 @@ void url_main_loop(void (*init)(void *opaque), void *opaque)
             url_display_request = 0;
         }
     }
+    return 0;
 }
 
 /* exit from url loop */


### PR DESCRIPTION
- rename `edit_new` as `qe_new_window`
- report error in `qe_new_buffer` and `qe_new_window` upon failure
- rename `qe_find_buffer_file` as `qe_find_buffer_filename`
- rename `read_charset` as `qe_parse_charset`
- reset yank buffer references in `eb_clear()`
- make `qe_init()` return error code and abort upon error