### PR TITLE
Improve C-like language colorizers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Quick Emacs (QEmacs)
  
 Copyright (c) 2000-2002 Fabrice Bellard
-Copyright (c) 2000-2023 Charlie Gordon
+Copyright (c) 2000-2024 Charlie Gordon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lang/clang.h
+++ b/lang/clang.h
@@ -92,7 +92,8 @@ enum {
     CLANG_FLAVOR = 0x7F,
 };
 
-int get_c_identifier(char *buf, int buf_size, const char32_t *p, int flavor);
+int get_c_identifier(char *dest, int size, char32_t c,
+                     const char32_t *str, int i, int n, int flavor);
 void c_indent_line(EditState *s, int offset0);
 
 #endif /* CLANG_H */

--- a/lang/rust.c
+++ b/lang/rust.c
@@ -221,9 +221,7 @@ static void rust_colorize_line(QEColorizeContext *cp,
                 /* identifiers match:
                  * "[a-zA-Z_\x80-\xff][a-zA-Z_0-9\x80-\xff]*"
                  */
-                klen = get_c_identifier(kbuf, countof(kbuf),
-                                        str + start, CLANG_RUST);
-                i = start + klen;
+                i += get_c_identifier(kbuf, countof(kbuf), c, str, i, n, CLANG_RUST);
 
                 if (str[i] == '!'
                 &&  (str[i + 1] == '(' || strequal(kbuf, "macro_rules"))) {

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -1965,23 +1965,28 @@ Convert a character to its numerical value as a hexadecimal digit
 
 Return the numerical value, or `-1` if the character is not a hex digit
 
-### `int get_c_identifier(char *buf, int buf_size, const char32_t *p, int flavor);`
+### `int get_c_identifier(char *dest, int size, char32_t c, const char32_t *str, int i0, int n, int flavor);`
 
-Grab a C ASCII identifier from a char32_t buffer for a given flavor.
+Grab an identifier from a `char32_t` buffer for a given C flavor,
+accept non-ASCII identifiers and encode in UTF-8.
 
-* argument `buf` a pointer to the destination array
+* argument `dest` a pointer to the destination array
 
-* argument `buf_size` the length of the destination array in bytes
+* argument `size` the length of the destination array in bytes
 
-* argument `p` a valid pointer to an array of codepoints
+* argument `c` the initial code point or `0` if none
+
+* argument `str` a valid pointer to an array of codepoints
+
+* argument `i` the index to the next codepoint
+
+* argument `n` the length of the codepoint array
 
 * argument `flavor` the language variant for identifier syntax
 
 Return the number of codepoints used in the source array.
 
 Note: `dest` can be a null pointer if `size` is `0`.
-
-Note: non-ASCII codepoints are accepted for CLANG_RUST but are not UTF-8 encoded
 
 ### `int32_t get_i8(const uint8_t *tab);`
 
@@ -2023,10 +2028,10 @@ Return the value read from memory
 
 Note: the value must be stored in memory in the native byte order
 
-### `int get_js_identifier(char *dest, int size, char32_t c, const char32_t *str, int i, int n);`
+### `int get_js_identifier(char *dest, int size, char32_t c, const char32_t *str, int i0, int n);`
 
-Grab an identifier from a char32_t buffer, accept non-ASCII identifiers
-and encode in UTF-8.
+Grab an identifier from a `char32_t` buffer,
+accept non-ASCII identifiers and encode in UTF-8.
 
 * argument `dest` a pointer to the destination array
 
@@ -2036,7 +2041,7 @@ and encode in UTF-8.
 
 * argument `str` a valid pointer to an array of codepoints
 
-* argument `i` the index to the next codepoint
+* argument `i0` the index to the next codepoint
 
 * argument `n` the length of the codepoint array
 

--- a/util.c
+++ b/util.c
@@ -716,6 +716,20 @@ void qe_strtolower(char *buf, int size, const char *str) {
     }
 }
 
+int qe_haslower(const char *str) {
+    /*@API utils
+       Check if a C string contains has ASCII lowercase letters.
+       @argument `str` a valid pointer to a C string
+       @return a boolean value, non zero if and only if the string contains
+       ASCII lowercase letters.
+     */
+    while (*str) {
+        if (qe_islower((unsigned char)*str++))
+            return 1;
+    }
+    return 0;
+}
+
 int memfind(const char *list, const char *s, int len) {
     /*@API utils.string
        Find a string fragment in a list of words separated by `|`.

--- a/util.h
+++ b/util.h
@@ -382,6 +382,7 @@ int qe_skip_spaces(const char **pp);
 int qe_strcollate(const char *s1, const char *s2);
 int qe_strtobool(const char *s, int def);
 void qe_strtolower(char *buf, int buf_size, const char *str);
+int qe_haslower(const char *str);
 int memfind(const char *list, const char *p, int len);
 int strfind(const char *list, const char *s);
 int strxfind(const char *list, const char *s);


### PR DESCRIPTION
* add `CLANG_C_TYPES` flag for generic C types
* add `CLANG_C_KEYWORDS` flag for generic C keywords
* add `CLANG_T_TYPES` flag for generic `xxx_t` types
* more explicit regex testing
* support for `u`, `U` and `u64` encoding prefixes
* improve comment detection in diff output for js and c3
* change `get_c_identifier` API for consistency
* add `is_c_identifier_start()` and `is_c_identifier_part()`
* move `qe_haslower` to **util.c**
* update C2 language keyword and type lists
* improve Pike colorizer