### PR TITLE
Fix crash bug on qe_load_all_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ DONE
 IDEAS
 .qerc
 cflags.mk
+TAGS

--- a/qe.c
+++ b/qe.c
@@ -11633,7 +11633,7 @@ static void qe_load_all_modules(QEmacsState *qs)
     char filename[MAX_FILENAME_SIZE];
     void *h;
     void *sym;
-    int (*init_func)(void);
+    int (*init_func)(QEmacsState *);
 
     ec = qs->ec;
     qs->ec.function = "load-all-modules";
@@ -11677,7 +11677,7 @@ static void qe_load_all_modules(QEmacsState *qs)
         }
 
         /* all is OK: we can init the module now */
-        (*init_func)();
+        (*init_func)(qs);
     }
     find_file_close(&ffst);
 

--- a/qe.h
+++ b/qe.h
@@ -646,10 +646,10 @@ void eb_delete_properties(EditBuffer *b, int offset, int offset2);
 /* dynamic module case */
 
 #define qe_module_init(fn) \
-        int qe__module_init(QEmacsState *qs) { return fn(qs); }
+        int __qe_module_init(QEmacsState *qs) { return fn(qs); }
 
 #define qe_module_exit(fn) \
-        void qe__module_exit(QEmacsState *qs) { fn(qs); }
+        void __qe_module_exit(QEmacsState *qs) { fn(qs); }
 
 #else /* QE_MODULE */
 


### PR DESCRIPTION
- Added TAGS entry in .gitignore
- When qe loads plugins, it didn't supply (QEmacsState` *) argument to initfunc