### PR TITLE
Fix crash bug in libqhtml

### DIFF
--- a/libqhtml/Makefile
+++ b/libqhtml/Makefile
@@ -1,7 +1,7 @@
 # Libqhtml tiny HTML/CSS rendering library for QEmacs
 #
 # Copyright (c) 2000-2002 Fabrice Bellard.
-# Copyright (c) 2000-2024 Charlie Gordon.
+# Copyright (c) 2000-2025 Charlie Gordon.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/libqhtml/css.c
+++ b/libqhtml/css.c
@@ -2,7 +2,7 @@
  * CSS core for qemacs.
  *
  * Copyright (c) 2000-2002 Fabrice Bellard.
- * Copyright (c) 2007-2024 Charlie Gordon.
+ * Copyright (c) 2007-2025 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -533,12 +533,9 @@ static inline int attribute_match(CSSStyleSheetAttributeEntry *e,
     CSSIdent attr;
     int op;
 
-    /* no match possible if no attribute */
-    if (!a)
-        return 0;
     attr = e->attr;
     op = e->op;
-    do {
+    for (; a != NULL; a = a->next) {
         if (attr == a->attr) {
             switch (op) {
             case CSS_ATTR_OP_SET:
@@ -554,16 +551,14 @@ static inline int attribute_match(CSSStyleSheetAttributeEntry *e,
                 break;
             }
         }
-        a = a->next;
-    } while (a != NULL);
+    }
     return 0;
 }
 
 /* return true if (box,pelement) matches simple selector ss (may
    recurse) */
 /* XXX: exclude anonymous boxes */
-static int selector_match(CSSSimpleSelector *ss,
-                          CSSBox *box)
+static int selector_match(CSSSimpleSelector *ss, CSSBox *box)
 {
     CSSStyleSheetAttributeEntry *ae;
     CSSBox *box1, *lbox;

--- a/libqhtml/css.h
+++ b/libqhtml/css.h
@@ -2,7 +2,7 @@
  * CSS core for qemacs.
  *
  * Copyright (c) 2000-2002 Fabrice Bellard.
- * Copyright (c) 2007-2024 Charlie Gordon.
+ * Copyright (c) 2007-2025 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/libqhtml/cssparse.c
+++ b/libqhtml/cssparse.c
@@ -2,6 +2,7 @@
  * CSS2 parser for qemacs.
  *
  * Copyright (c) 2000-2002 Fabrice Bellard.
+ * Copyright (c) 2007-2025 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -875,7 +876,8 @@ static void beat(CSSParseState *b, int *ch_ptr, const char *str)
     *ch_ptr = ch;
 }
 
-static void parse_simple_selector(CSSSimpleSelector *ss, CSSParseState *b,
+static void parse_simple_selector(CSSSimpleSelector *ss, // output only
+                                  CSSParseState *b,
                                   int *ch_ptr)
 {
     char value[1024];

--- a/libqhtml/csstoqe.c
+++ b/libqhtml/csstoqe.c
@@ -3,7 +3,10 @@
  * linked with qemacs
  *
  * Copyright (c) 2002 Fabrice Bellard.
- * Copyright (c) 2007-2023 Charlie Gordon.
+ * Copyright (c) 2007-2025 Charlie Gordon.
+ *
+ * This utility generates C source code for a string containing the minimized
+ * version of the css input file for embedding in a C application.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* fix crash on "https://support.apple.com/kb/HT208050"
* add missing initializer (stupid oversight)
* fix bogus overflow test (another nasty bug waiting to bite) We desperately need warnings or idioms against such stupid errors. Using constructors for all locally defined structures seems advidsable,