### PR TITLE
Improve colorization for c, c2 and tcl

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,10 @@
 
 ## Current work
 
+* add cat mode where colorizer is chosen based on extension of filename between ==> xxx <==
+* start directory of make command should be the default directory of current buffer
+* delete *bufed* buffer when exiting bufed or clear flags on `bufed` invocation
+
 * should `mark` be a window variable instead of a buffer variable?
 * should `tab-width` be a window variable instead of or in addition to a buffer variable?
 * extra modes for drujensen/fib repo:

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -600,7 +600,7 @@ static void c_colorize_line(QEColorizeContext *cp,
         normal:
             if (state & IN_C_PREPROCESS)
                 break;
-            if (qe_isdigit(c) || (c == '.' && qe_isdigit(str[i + 1]))) {
+            if (qe_isdigit(c) || (c == '.' && qe_isdigit(str[i]))) {
                 /* XXX: parsing ppnumbers, which is OK for C and C++ */
                 /* XXX: should parse actual number syntax */
                 /* XXX: D ignores embedded '_' and accepts l,u,U,f,F,i suffixes */
@@ -1558,9 +1558,8 @@ static const char c2_keywords[] = {
 };
 
 static const char c2_types[] = {
-    "bool|i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64|void|"
-    "reg8|reg16|reg32|reg64|"
-    "char"  // same as i8, a design error
+    "void|bool|char|i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64|"
+    "reg8|reg16|reg32|reg64|va_list"
 };
 
 static ModeDef c2_mode = {

--- a/lang/tcl.c
+++ b/lang/tcl.c
@@ -299,7 +299,7 @@ dispatch_colstate:
             // XXX: should use a state machine
             if (qe_isalpha(c)) {
                 if (atclose) {
-                    if (strfind("else|elseif|default|trap|on|finally", kbuf)) {
+                    if (strfind("else|elseif|default|trap|on|finally|break|continue|return", kbuf)) {
                         style = TCL_STYLE_KEYWORD;
                         break;
                     }


### PR DESCRIPTION
* c: fix a glitch in number colorizer
* c2: add type `va_list`
* tcl: add keywords `break`, `continue`, `return`