### PR TITLE
fix --enable-tiny build option

### DIFF
--- a/configure
+++ b/configure
@@ -696,7 +696,7 @@ fi
 
 if test "$tiny" = "yes" ; then
   echo "#define CONFIG_TINY 1" >> $TMPH
-  echo "CONFIG_TINY=yes" >> $TMPMAK
+  echo "TARGET_TINY=yes" >> $TMPMAK
 fi
 
 if test "$html" = "yes" ; then


### PR DESCRIPTION
Tiny build fails as 
`Makefile:142` checks for ``TARGET_TINY`` not for ``CONFIG_TINY``. 
```make
ifdef TARGET_TINY
ECHO_CFLAGS += -DCONFIG_TINY
CFLAGS += -DCONFIG_TINY -Os
#CFLAGS += -m32
#LDFLAGS += -m32
else
OBJS+= extras.o variables.o
endif
```