### PR TITLE
fix #14: handle wrap mode when window is narrow

### DIFF
--- a/qe.c
+++ b/qe.c
@@ -3880,6 +3880,8 @@ void display_init(DisplayState *ds, EditState *e, enum DisplayType do_disp,
          */
         if (e->width >= e->screen->width * 3 / 4) {
             ds->wrap = WRAP_LINE;
+        } else {
+            ds->wrap = WRAP_TRUNCATE;
         }
     }
     /* select default values */


### PR DESCRIPTION
 Fixes #14

When `display_init()` automatically selects a wrap mode for windows, it only set `ds->wrap = WRAP_LINE` when the window width was >= 3/4 of screen width.