### PR TITLE
fix bottom right corner refresh

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -1662,9 +1662,6 @@ static void tty_dpy_flush(QEditScreen *s)
     gotopos = 0;
 
     shadow = ts->screen_size;
-    /* We cannot print anything on the bottom right screen cell,
-     * pretend it's OK: */
-    ts->screen[shadow - 1] = ts->screen[2 * shadow - 1];
 
     for (y = 0; y < s->height; y++) {
         if (ts->line_updated[y]) {

--- a/tty.c
+++ b/tty.c
@@ -1663,6 +1663,16 @@ static void tty_dpy_flush(QEditScreen *s)
 
     shadow = ts->screen_size;
 
+#if 0
+    /* This hack is only required for pretty old terminals.
+     * We don't need it in most of the modern terminals so we
+     * disable it currently.
+     *
+     * We cannot print anything on the bottom right screen cell,
+     * pretend it's OK: */
+    ts->screen[shadow - 1] = ts->screen[2 * shadow - 1];
+#endif
+
     for (y = 0; y < s->height; y++) {
         if (ts->line_updated[y]) {
             ts->line_updated[y] = 0;


### PR DESCRIPTION
This hack is only needed in old terminals. In modern terminals we do not need this. Besides, removing this hack will refresh the bottom right corner.

### Before fix

<img width="889" height="585" alt="The right bottom corner is not refreshed" src="https://github.com/user-attachments/assets/4e180d76-8226-40cc-8a1a-88fead50742a" />

### After fix

<img width="889" height="585" alt="The right bottom corner is refreshed correctly" src="https://github.com/user-attachments/assets/6f53fd2a-6186-4f8a-ba9e-aa41e769e5c4" />


