### PR TITLE
winlayout: persist custom window split ratio

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -485,6 +485,7 @@ static void do_adjust_window(EditState *s, int argval, int flags)
                 e->y1 += delta;
             if (e->y2 == y)
                 e->y2 += delta;
+            update_split_ratio(e);
         }
     }
     qs->complete_refresh = 1;

--- a/qe.c
+++ b/qe.c
@@ -7228,6 +7228,8 @@ EditState *qe_new_window(EditBuffer *b,
     s->y1 = y1;
     s->x2 = x1 + width;
     s->y2 = y1 + height;
+    s->split_x_ratio = s->split_y_ratio = 0;
+    s->split_width_ratio = s->split_height_ratio = 1000;
     s->flags = flags;
     compute_client_area(s);
 
@@ -9516,12 +9518,11 @@ void do_refresh(EditState *s1)
                 e->y2 = content_height;
                 e->x2 = width;
             } else {
-                /* NOTE: to ensure that no rounding errors are made,
-                   we resize the absolute coordinates */
-                e->x1 = (e->x1 * width + qs->width / 2) / qs->width;
-                e->x2 = (e->x2 * width + qs->width / 2) / qs->width;
-                e->y1 = (e->y1 * content_height + qs->content_height / 2) / qs->content_height;
-                e->y2 = (e->y2 * content_height + qs->content_height / 2) / qs->content_height;
+                e->x1 = (width * e->split_x_ratio + 500) / 1000;
+                e->x2 = e->x1 + (width * e->split_width_ratio + 500) / 1000;
+
+                e->y1 = (content_height * e->split_y_ratio + 500) / 1000;
+                e->y2 = e->y1 + (content_height * e->split_height_ratio + 500) / 1000;
             }
         }
 
@@ -9777,6 +9778,28 @@ void do_delete_hidden_windows(EditState *s)
     }
 }
 
+void update_split_ratio(EditState *s)
+{
+    int total_w = s->qs->width;
+    int total_h = s->qs->content_height;
+
+    s->split_x_ratio = s->x1 * 1000 / total_w;
+    s->split_y_ratio = s->y1 * 1000 / total_h;
+
+    s->split_width_ratio = (s->x2 - s->x1) * 1000 / total_w;
+    s->split_height_ratio = (s->y2 - s->y1) * 1000 / total_h;
+}
+
+void update_all_split_ratios(QEmacsState *qs)
+{
+    EditState *e;
+    for (e = qs->first_window; e; e = e->next_window) {
+        if (e->flags & WF_MINIBUF)
+            continue;
+        update_split_ratio(e);
+    }
+}
+
 EditState *qe_split_window(EditState *s, int side_by_side, int prop)
 {
     EditState *e;
@@ -9829,6 +9852,9 @@ EditState *qe_split_window(EditState *s, int side_by_side, int prop)
 
     /* reposition new window in window list just after s */
     edit_attach(e, s->next_window);
+
+    update_split_ratio(s);
+    update_split_ratio(e);
 
     do_refresh(s);
     return e;
@@ -10508,6 +10534,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
                 qs->motion_y = mouse_y;
             }
             if (changed) {
+                update_split_ratio(e);
                 compute_client_area(e);
                 //do_refresh(qs->first_window);
                 qs->complete_refresh = 1;
@@ -10520,6 +10547,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
         if ((mouse_y / scale) != (qs->motion_y / scale)) {
             qs->motion_y = mouse_y;
             window_resize(e, e->x2 - e->x1, qs->motion_y - e->y1);
+            update_all_split_ratios(qs);
             do_refresh(qs->first_window);
             qe_display(qs);
         }
@@ -10529,6 +10557,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
         if ((mouse_x / scale) != (qs->motion_x / scale)) {
             qs->motion_x = mouse_x;
             window_resize(e, qs->motion_x - e->x1, e->y2 - e->y1);
+            update_all_split_ratios(qs);
             do_refresh(qs->first_window);
             qe_display(qs);
         }

--- a/qe.c
+++ b/qe.c
@@ -7228,8 +7228,6 @@ EditState *qe_new_window(EditBuffer *b,
     s->y1 = y1;
     s->x2 = x1 + width;
     s->y2 = y1 + height;
-    s->split_x_ratio = s->split_y_ratio = 0;
-    s->split_width_ratio = s->split_height_ratio = 1000;
     s->flags = flags;
     compute_client_area(s);
 
@@ -9518,11 +9516,7 @@ void do_refresh(EditState *s1)
                 e->y2 = content_height;
                 e->x2 = width;
             } else {
-                e->x1 = (width * e->split_x_ratio + 500) / 1000;
-                e->x2 = e->x1 + (width * e->split_width_ratio + 500) / 1000;
-
-                e->y1 = (content_height * e->split_y_ratio + 500) / 1000;
-                e->y2 = e->y1 + (content_height * e->split_height_ratio + 500) / 1000;
+                restore_coordinate_from_ratio(e);
             }
         }
 
@@ -9780,14 +9774,14 @@ void do_delete_hidden_windows(EditState *s)
 
 void update_split_ratio(EditState *s)
 {
-    int total_w = s->qs->width;
-    int total_h = s->qs->content_height;
+    int total_w = s->screen->width;
+    int total_h = s->screen->height;
 
-    s->split_x_ratio = s->x1 * 1000 / total_w;
-    s->split_y_ratio = s->y1 * 1000 / total_h;
+    s->xx1 = s->x1 * UNIT_SIZE / total_w;
+    s->xx2 = s->x2 * UNIT_SIZE / total_w;
 
-    s->split_width_ratio = (s->x2 - s->x1) * 1000 / total_w;
-    s->split_height_ratio = (s->y2 - s->y1) * 1000 / total_h;
+    s->yy1 = s->y1 * UNIT_SIZE / total_h;
+    s->yy2 = s->y2 * UNIT_SIZE / total_h;
 }
 
 void update_all_split_ratios(QEmacsState *qs)
@@ -9798,6 +9792,18 @@ void update_all_split_ratios(QEmacsState *qs)
             continue;
         update_split_ratio(e);
     }
+}
+
+void restore_coordinate_from_ratio(EditState *s)
+{
+    int total_w = s->screen->width;
+    int total_h = s->screen->height;
+
+    s->x1 = s->xx1 * total_w / UNIT_SIZE;
+    s->x2 = s->xx2 * total_w / UNIT_SIZE;
+
+    s->y1 = s->yy1 * total_h / UNIT_SIZE;
+    s->y2 = s->yy2 * total_h / UNIT_SIZE;
 }
 
 EditState *qe_split_window(EditState *s, int side_by_side, int prop)

--- a/qe.c
+++ b/qe.c
@@ -7215,6 +7215,8 @@ EditState *qe_new_window(EditBuffer *b,
     s->y1 = y1;
     s->x2 = x1 + width;
     s->y2 = y1 + height;
+    s->split_x_ratio = s->split_y_ratio = 0;
+    s->split_width_ratio = s->split_height_ratio = 1000;
     s->flags = flags;
     compute_client_area(s);
 
@@ -9504,12 +9506,11 @@ void do_refresh(EditState *s1)
                 e->y2 = content_height;
                 e->x2 = width;
             } else {
-                /* NOTE: to ensure that no rounding errors are made,
-                   we resize the absolute coordinates */
-                e->x1 = (e->x1 * width + qs->width / 2) / qs->width;
-                e->x2 = (e->x2 * width + qs->width / 2) / qs->width;
-                e->y1 = (e->y1 * content_height + qs->content_height / 2) / qs->content_height;
-                e->y2 = (e->y2 * content_height + qs->content_height / 2) / qs->content_height;
+                e->x1 = (width * e->split_x_ratio + 500) / 1000;
+                e->x2 = e->x1 + (width * e->split_width_ratio + 500) / 1000;
+
+                e->y1 = (content_height * e->split_y_ratio + 500) / 1000;
+                e->y2 = e->y1 + (content_height * e->split_height_ratio + 500) / 1000;
             }
         }
 
@@ -9762,6 +9763,28 @@ void do_delete_hidden_windows(EditState *s)
     }
 }
 
+void update_split_ratio(EditState *s)
+{
+    int total_w = s->qs->width;
+    int total_h = s->qs->content_height;
+
+    s->split_x_ratio = s->x1 * 1000 / total_w;
+    s->split_y_ratio = s->y1 * 1000 / total_h;
+
+    s->split_width_ratio = (s->x2 - s->x1) * 1000 / total_w;
+    s->split_height_ratio = (s->y2 - s->y1) * 1000 / total_h;
+}
+
+void update_all_split_ratios(QEmacsState *qs)
+{
+    EditState *e;
+    for (e = qs->first_window; e; e = e->next_window) {
+        if (e->flags & WF_MINIBUF)
+            continue;
+        update_split_ratio(e);
+    }
+}
+
 /* XXX: add minimum size test and refuse to split if reached */
 EditState *qe_split_window(EditState *s, int side_by_side, int prop)
 {
@@ -9799,6 +9822,9 @@ EditState *qe_split_window(EditState *s, int side_by_side, int prop)
 
     /* reposition new window in window list just after s */
     edit_attach(e, s->next_window);
+
+    update_split_ratio(s);
+    update_split_ratio(e);
 
     do_refresh(s);
     return e;
@@ -10478,6 +10504,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
                 qs->motion_y = mouse_y;
             }
             if (changed) {
+                update_split_ratio(e);
                 compute_client_area(e);
                 //do_refresh(qs->first_window);
                 qs->complete_refresh = 1;
@@ -10490,6 +10517,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
         if ((mouse_y / scale) != (qs->motion_y / scale)) {
             qs->motion_y = mouse_y;
             window_resize(e, e->x2 - e->x1, qs->motion_y - e->y1);
+            update_all_split_ratios(qs);
             do_refresh(qs->first_window);
             qe_display(qs);
         }
@@ -10499,6 +10527,7 @@ static void handle_mouse_motion(EditState *e, QEEvent *ev) {
         if ((mouse_x / scale) != (qs->motion_x / scale)) {
             qs->motion_x = mouse_x;
             window_resize(e, qs->motion_x - e->x1, e->y2 - e->y1);
+            update_all_split_ratios(qs);
             do_refresh(qs->first_window);
             qe_display(qs);
         }

--- a/qe.h
+++ b/qe.h
@@ -101,6 +101,8 @@ typedef struct QEProperty QEProperty;
 #define MAX_BUFFERNAME_SIZE  256        /* Size for a buffer name buffer */
 #define MAX_CMDNAME_SIZE     32         /* Size for a command name buffer */
 
+#define UNIT_SIZE (1 << 10) /* window corrdinates ratio */
+
 extern const char str_version[];
 extern const char str_credits[];
 
@@ -773,11 +775,7 @@ struct EditState {
     int cols, rows;
     /* full window size, including borders */
     int x1, y1, x2, y2;         /* window coordinates in device units */
-    //int xx1, yy1, xx2, yy2;     /* window coordinates in 1/1000 */
-    int split_x_ratio;          /* window left coordinate ratio in 1000x */
-    int split_y_ratio;          /* window top coordinate ratio in 1000x */
-    int split_width_ratio;      /* window width ratio in 1000x */
-    int split_height_ratio;     /* window height ratio in 1000x */
+    int xx1, yy1, xx2, yy2;     /* window coordinates in 1/UNIT_SIZE */
 
     int flags; /* display flags */
 #define WF_POPUP      0x0001 /* popup window (with borders) */
@@ -1508,6 +1506,7 @@ int get_line_height(QEditScreen *screen, EditState *s, QETermStyle style);
 void do_refresh(EditState *s);
 void update_split_ratio(EditState *s);
 void update_all_split_ratios(QEmacsState *qs);
+void restore_coordinate_from_ratio(EditState *s);
 // should take direction argument
 void do_other_window(EditState *s);
 void do_previous_window(EditState *s);

--- a/qe.h
+++ b/qe.h
@@ -774,6 +774,10 @@ struct EditState {
     /* full window size, including borders */
     int x1, y1, x2, y2;         /* window coordinates in device units */
     //int xx1, yy1, xx2, yy2;     /* window coordinates in 1/1000 */
+    int split_x_ratio;          /* window left coordinate ratio in 1000x */
+    int split_y_ratio;          /* window top coordinate ratio in 1000x */
+    int split_width_ratio;      /* window width ratio in 1000x */
+    int split_height_ratio;     /* window height ratio in 1000x */
 
     int flags; /* display flags */
 #define WF_POPUP      0x0001 /* popup window (with borders) */
@@ -1502,6 +1506,8 @@ void qe_kill_buffer(QEmacsState *qs, EditBuffer *b);
 int get_glyph_width(QEditScreen *screen, EditState *s, QETermStyle style, char32_t c);
 int get_line_height(QEditScreen *screen, EditState *s, QETermStyle style);
 void do_refresh(EditState *s);
+void update_split_ratio(EditState *s);
+void update_all_split_ratios(QEmacsState *qs);
 // should take direction argument
 void do_other_window(EditState *s);
 void do_previous_window(EditState *s);

--- a/qe.h
+++ b/qe.h
@@ -773,6 +773,10 @@ struct EditState {
     /* full window size, including borders */
     int x1, y1, x2, y2;         /* window coordinates in device units */
     //int xx1, yy1, xx2, yy2;     /* window coordinates in 1/1000 */
+    int split_x_ratio;          /* window left coordinate ratio in 1000x */
+    int split_y_ratio;          /* window top coordinate ratio in 1000x */
+    int split_width_ratio;      /* window width ratio in 1000x */
+    int split_height_ratio;     /* window height ratio in 1000x */
 
     int flags; /* display flags */
 #define WF_POPUP      0x0001 /* popup window (with borders) */
@@ -1501,6 +1505,8 @@ void qe_kill_buffer(QEmacsState *qs, EditBuffer *b);
 int get_glyph_width(QEditScreen *screen, EditState *s, QETermStyle style, char32_t c);
 int get_line_height(QEditScreen *screen, EditState *s, QETermStyle style);
 void do_refresh(EditState *s);
+void update_split_ratio(EditState *s);
+void update_all_split_ratios(QEmacsState *qs);
 // should take direction argument
 void do_other_window(EditState *s);
 void do_previous_window(EditState *s);


### PR DESCRIPTION
# Description
This patch improves qemacs window layout management by persisting user-customized window split ratios.

# Changes
Keep user-defined window proportion when terminal window size changes.

# Problem Fixed
Previously, manually adjusting window size by dragging split borders would not update the relative ratio data. After resizing the window several times, the window split ratio changed incorrectly.