### PR TITLE
docfix: fix LICENCE file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Read the file [qe-doc.html](qe-doc.html).
 ## Licensing
 
 QEmacs is released under the MIT license.
-(read the accompanying [LICENCE](LICENCE) file).
+(read the accompanying [LICENSE](LICENSE) file).
 
 ## Contributing to QEmacs
 

--- a/qe.c
+++ b/qe.c
@@ -10851,7 +10851,7 @@ static void show_usage(void)
     }
     printf("\n"
            "Report bugs to bug@qemacs.org.  First, please see the Bugs\n"
-           "section of the QEmacs manual or the file BUGS.\n");
+           "section of the QEmacs manual.\n");
     exit(1);
 }
 


### PR DESCRIPTION
- The filename is LICENSE, not LICENCE.
- There is no BUGS file in the repo.