### PR TITLE
CI: disable linux-s390x target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,21 +41,21 @@ jobs:
           ./configure
           make CONFIG_32BIT=y
 
-  linux-s390x:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: alpine.sh {0}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: jirutka/setup-alpine@v1
-        with:
-          arch: s390x
-          packages: "build-base make"
-      - name: build
-        run: |
-          ./configure
-          make
+#  linux-s390x:
+#    runs-on: ubuntu-latest
+#    defaults:
+#      run:
+#        shell: alpine.sh {0}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: jirutka/setup-alpine@v1
+#        with:
+#          arch: s390x
+#          packages: "build-base make"
+#      - name: build
+#        run: |
+#          ./configure
+#          make
 
   macos:
     name: macOS


### PR DESCRIPTION
* `linux-s390x` continuous integration target takes too much time (>10mn)