### PR TITLE
bugfix: fix coredump when resizing terminal window

### DIFF
--- a/qe.h
+++ b/qe.h
@@ -110,7 +110,7 @@ void set_write_handler(int fd, void (*cb)(void *opaque), void *opaque);
 int set_pid_handler(int pid,
                     void (*cb)(void *opaque, int status), void *opaque);
 void url_exit(void);
-void url_redisplay(void);
+void url_redisplay(QEditScreen *s);
 void register_bottom_half(void (*cb)(void *opaque), void *opaque);
 void unregister_bottom_half(void (*cb)(void *opaque), void *opaque);
 

--- a/tty.c
+++ b/tty.c
@@ -658,11 +658,7 @@ static void tty_term_resize(qe__unused__ int sig)
     QEditScreen *s = tty_screen;
 
     if (s) {
-        tty_dpy_invalidate(s);
-
-        //fprintf(stderr, "tty_term_resize: width=%d, height=%d\n", s->width, s->height);
-
-        url_redisplay();
+        url_redisplay(s);
     }
 }
 

--- a/unix.c
+++ b/unix.c
@@ -346,9 +346,10 @@ void url_exit(void)
 }
 
 /* asynchronous redisplay signal received */
-void url_redisplay(void)
+void url_redisplay(QEditScreen *s)
 {
     url_display_request = 1;
+    s->qs->complete_refresh = 1;
 }
 
 int get_clock_ms(void) {


### PR DESCRIPTION
In the signal handler for the signal SIGWINCH tty_term_resize, we call tty_dpy_invalidate function. In this function, we change the screen_size and other critical fields.

While the process is executing the function tty_dpy_flush, and another SIGWINCH occurs, then the screen_size is changed. And tty_dpy_flush will access invalid memory which leads to coredump.

In the signal hander of SIGWINCH, we only need to set the flag complete_refresh.

Here are two examples of the coredump (The reasons are the same):

## Coredump 1

```
Hint: You are currently not seeing messages from other users and the system.
      Users in the 'systemd-journal' group can see all messages. Pass -q to
      turn off this notice.
           PID: 80876 (qe_debug)
           UID: 1000 (rakuyo)
           GID: 1000 (rakuyo)
        Signal: 11 (SEGV)
     Timestamp: Sun 2026-04-26 21:37:53 CST (8s ago)
  Command Line: ./qe_debug -nw qe.c
    Executable: /home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug
 Control Group: /user.slice/user-1000.slice/user@1000.service/app.slice/app-dbus\x2d:1.2\x2dorg.gnome.Console.slice/vte-spawn-dacd4e79-a47b-4af5-a1ad-cfa9a518aff7.scope
          Unit: user@1000.service
     User Unit: vte-spawn-dacd4e79-a47b-4af5-a1ad-cfa9a518aff7.scope
         Slice: user-1000.slice
     Owner UID: 1000 (rakuyo)
       Boot ID: a8d13469ec534f3b85aa975305cacce8
    Machine ID: c792aa5e0a344d0b8cd2329c52146ce2
      Hostname: Yharnam
       Storage: /var/lib/systemd/coredump/core.qe_debug.1000.a8d13469ec534f3b85aa975305cacce8.80876.1777210673000000.zst (present)
  Size on Disk: 167K
       Message: Process 80876 (qe_debug) of user 1000 dumped core.
                Stack trace of thread 80876:
                #0  0x0000562a971904f3 tty_dpy_flush (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x6c4f3)
                #1  0x0000562a9715bb2a dpy_flush (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x37b2a)
                #2  0x0000562a9715ba82 qe_display (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x37a82)
                #3  0x0000562a9718f291 url_main_loop (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x6b291)
                #4  0x0000562a97164d1a main (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x40d1a)
                #5  0x00007fb507e2b2fb __libc_start_call_main (libc.so.6 + 0x2b2fb)
                #6  0x00007fb507e2b3cb __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2b3cb)
                #7  0x0000562a9714c735 _start (/home/rakuyo/fun/tmp/qemacs/qemacs-github/qe_debug + 0x28735)
                ELF object binary architecture: AMD x86-64
```

## Coredump 2

```
Hint: You are currently not seeing messages from other users and the system.
      Users in the 'systemd-journal' group can see all messages. Pass -q to
      turn off this notice.
           PID: 97799 (qe_debug)
           UID: 1000 (rakuyo)
           GID: 1000 (rakuyo)
        Signal: 6 (ABRT)
     Timestamp: Sun 2026-04-26 22:31:38 CST (9s ago)
  Command Line: ./qe_debug -nw qe.c
    Executable: /home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug
 Control Group: /user.slice/user-1000.slice/user@1000.service/app.slice/app-dbus\x2d:1.2\x2dorg.gnome.Console.slice/vte-spawn-e7b84447-6bdc-400a-ba23-01ccc9202dd3.scope
          Unit: user@1000.service
     User Unit: vte-spawn-e7b84447-6bdc-400a-ba23-01ccc9202dd3.scope
         Slice: user-1000.slice
     Owner UID: 1000 (rakuyo)
       Boot ID: a8d13469ec534f3b85aa975305cacce8
    Machine ID: c792aa5e0a344d0b8cd2329c52146ce2
      Hostname: Yharnam
       Storage: /var/lib/systemd/coredump/core.qe_debug.1000.a8d13469ec534f3b85aa975305cacce8.97799.1777213898000000.zst (present)
  Size on Disk: 177.9K
       Message: Process 97799 (qe_debug) of user 1000 dumped core.
                Stack trace of thread 97799:
                #0  0x00007fa619c9dc9c __pthread_kill_implementation (libc.so.6 + 0x9dc9c)
                #1  0x00007fa619c42786 raise (libc.so.6 + 0x42786)
                #2  0x00007fa619c2934b abort (libc.so.6 + 0x2934b)
                #3  0x00007fa619c2a3ad __libc_message_impl.cold (libc.so.6 + 0x2a3ad)
                #4  0x00007fa619ca8ab7 malloc_printerr (libc.so.6 + 0xa8ab7)
                #5  0x00007fa619cad07c _int_realloc (libc.so.6 + 0xad07c)
                #6  0x00007fa619cae331 realloc (libc.so.6 + 0xae331)
                #7  0x0000564cf8a8c778 qe_realloc_bytes (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x49778)
                #8  0x0000564cf8ab0a7c tty_dpy_invalidate (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x6da7c)
                #9  0x0000564cf8ab1a36 tty_term_resize (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x6ea36)
                #10 0x00007fa619c428e0 __restore_rt (libc.so.6 + 0x428e0)
                #11 0x00007fa619c97f9a __internal_syscall_cancel (libc.so.6 + 0x97f9a)
                #12 0x00007fa619c97fc1 __syscall_cancel (libc.so.6 + 0x97fc1)
                #13 0x00007fa619d1e0c3 __select (libc.so.6 + 0x11e0c3)
                #14 0x0000564cf8aae28d url_block (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x6b28d)
                #15 0x0000564cf8aae117 url_main_loop (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x6b117)
                #16 0x0000564cf8a83bca main (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x40bca)
                #17 0x00007fa619c2b2fb __libc_start_call_main (libc.so.6 + 0x2b2fb)
                #18 0x00007fa619c2b3cb __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2b3cb)
                #19 0x0000564cf8a6b735 _start (/home/rakuyo/fun/tmp/qemacs/qemacs-github-upstream/qe_debug + 0x28735)
                ELF object binary architecture: AMD x86-64
```