### PR TITLE
feature: Add back-to-indentation command

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2679,6 +2679,21 @@ int eb_goto_bol2(EditBuffer *b, int offset, int *countp)
     return offset;
 }
 
+/* return offset of the first non-whitespace character of the line containing offset */
+int eb_goto_bol_nspace(EditBuffer *b, int offset)
+{
+    int offset1 = eb_goto_bol(b, offset);
+
+    for (;;) {
+        offset = offset1;
+        char32_t c = eb_nextc(b, offset, &offset1);
+        if (qe_isblank(c))
+            continue;
+        else
+            return offset;
+    }
+}
+
 /* test for blank line starting at <offset>.
  * return 0 if not blank.
  * return 1 if blank and store start of next line in <*offset1>.

--- a/buffer.c
+++ b/buffer.c
@@ -2679,7 +2679,9 @@ int eb_goto_bol2(EditBuffer *b, int offset, int *countp)
     return offset;
 }
 
-/* return offset of the first non-whitespace character of the line containing offset */
+/* return offset of the first non-whitespace character of the line containing offset.
+ * If there are no non-whitespace characters on the line, return the end of line.
+ */
 int eb_goto_bol_nspace(EditBuffer *b, int offset)
 {
     int offset1 = eb_goto_bol(b, offset);

--- a/buffer.c
+++ b/buffer.c
@@ -2689,9 +2689,7 @@ int eb_goto_bol_nspace(EditBuffer *b, int offset)
     for (;;) {
         offset = offset1;
         char32_t c = eb_nextc(b, offset, &offset1);
-        if (qe_isblank(c))
-            continue;
-        else
+        if (!qe_isblank(c))
             return offset;
     }
 }

--- a/qe.c
+++ b/qe.c
@@ -11143,7 +11143,7 @@ static const CmdDef basic_commands[] = {
           "Move point to the beginning of the line",
           do_bol)
     CMD0( "back-to-indentation", "",
-          "Move point to the first non-whitespace character on this line.",
+          "Move point to the first non-whitespace character on the current line",
           do_bol_nspace)
     CMD0( "end-of-line", "C-e, end, S-end",
           "Move point to the end of the line",

--- a/qe.c
+++ b/qe.c
@@ -149,8 +149,6 @@ void qe_register_mode(QEmacsState *qs, ModeDef *m, int flags)
             m->move_left_right = text_move_left_right_visual;
         if (!m->move_bol)
             m->move_bol = text_move_bol;
-        if (!m->move_bol_nspace)
-            m->move_bol_nspace = text_move_bol_nspace;
         if (!m->move_eol)
             m->move_eol = text_move_eol;
         if (!m->move_bof)
@@ -808,9 +806,7 @@ void do_bol(EditState *s)
 void do_bol_nspace(EditState *s)
 {
     do_maybe_set_mark(s);
-
-    if (s->mode->move_bol_nspace)
-        s->mode->move_bol_nspace(s);
+    text_move_bol_nspace(s);
 }
 
 void do_eol(EditState *s)
@@ -10713,7 +10709,6 @@ ModeDef text_mode = {
     .move_up_down = text_move_up_down,
     .move_left_right = text_move_left_right_visual,
     .move_bol = text_move_bol,
-    .move_bol_nspace = text_move_bol_nspace,
     .move_eol = text_move_eol,
     .move_bof = text_move_bof,
     .move_eof = text_move_eof,

--- a/qe.c
+++ b/qe.c
@@ -149,6 +149,8 @@ void qe_register_mode(QEmacsState *qs, ModeDef *m, int flags)
             m->move_left_right = text_move_left_right_visual;
         if (!m->move_bol)
             m->move_bol = text_move_bol;
+        if (!m->move_bol_nspace)
+            m->move_bol_nspace = text_move_bol_nspace;
         if (!m->move_eol)
             m->move_eol = text_move_eol;
         if (!m->move_bof)
@@ -803,6 +805,14 @@ void do_bol(EditState *s)
         s->mode->move_bol(s);
 }
 
+void do_bol_nspace(EditState *s)
+{
+    do_maybe_set_mark(s);
+
+    if (s->mode->move_bol_nspace)
+        s->mode->move_bol_nspace(s);
+}
+
 void do_eol(EditState *s)
 {
     do_maybe_set_mark(s);
@@ -836,6 +846,11 @@ void text_move_eof(EditState *s)
 void text_move_bol(EditState *s)
 {
     s->offset = eb_goto_bol(s->b, s->offset);
+}
+
+void text_move_bol_nspace(EditState *s)
+{
+    s->offset = eb_goto_bol_nspace(s->b, s->offset);
 }
 
 void text_move_eol(EditState *s)
@@ -10698,6 +10713,7 @@ ModeDef text_mode = {
     .move_up_down = text_move_up_down,
     .move_left_right = text_move_left_right_visual,
     .move_bol = text_move_bol,
+    .move_bol_nspace = text_move_bol_nspace,
     .move_eol = text_move_eol,
     .move_bof = text_move_bof,
     .move_eof = text_move_eof,
@@ -11126,6 +11142,9 @@ static const CmdDef basic_commands[] = {
     CMD0( "beginning-of-line", "C-a, home, S-home",
           "Move point to the beginning of the line",
           do_bol)
+    CMD0( "back-to-indentation", "",
+          "Move point to the first non-whitespace character on this line.",
+          do_bol_nspace)
     CMD0( "end-of-line", "C-e, end, S-end",
           "Move point to the end of the line",
           do_eol)

--- a/qe.h
+++ b/qe.h
@@ -612,6 +612,7 @@ int eb_fgets(EditBuffer *b, char *buf, int size,
 int eb_prev_line(EditBuffer *b, int offset);
 int eb_goto_bol(EditBuffer *b, int offset);
 int eb_goto_bol2(EditBuffer *b, int offset, int *countp);
+int eb_goto_bol_nspace(EditBuffer *b, int offset);
 int eb_is_blank_line(EditBuffer *b, int offset, int *offset1);
 int eb_is_in_indentation(EditBuffer *b, int offset);
 int eb_goto_eol(EditBuffer *b, int offset);
@@ -881,6 +882,7 @@ struct ModeDef {
     void (*move_up_down)(EditState *s, int dir);
     void (*move_left_right)(EditState *s, int dir);
     void (*move_bol)(EditState *s);
+    void (*move_bol_nspace)(EditState *s);
     void (*move_eol)(EditState *s);
     void (*move_bof)(EditState *s);
     void (*move_eof)(EditState *s);
@@ -1589,6 +1591,7 @@ void do_kill_beginning_of_line(EditState *s, int argval);
 void do_kill_whole_line(EditState *s, int n);
 void do_kill_word(EditState *s, int n);
 void text_move_bol(EditState *s);
+void text_move_bol_nspace(EditState *s);
 void text_move_eol(EditState *s);
 void text_move_bof(EditState *s);
 void text_move_eof(EditState *s);

--- a/qe.h
+++ b/qe.h
@@ -882,7 +882,6 @@ struct ModeDef {
     void (*move_up_down)(EditState *s, int dir);
     void (*move_left_right)(EditState *s, int dir);
     void (*move_bol)(EditState *s);
-    void (*move_bol_nspace)(EditState *s);
     void (*move_eol)(EditState *s);
     void (*move_bof)(EditState *s);
     void (*move_eof)(EditState *s);


### PR DESCRIPTION
Move point to the first non-whitespace character on this line.

In Emacs, this built-in command [back-to-indentation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Indentation-Commands.html) binds to `M-m` which I think is very useful, so I tried to add this feature.

In QEmacs, `M-m` is bound to the command `set-next-mode` which I guess is not used often. I didn't change this default setting. We can add the following line to user config file `~/.qe/config`

```
global_set_key("M-m", "back-to-indentation");
```
