### PR TITLE
fix: occur command didn't clear the previous result

### DIFF
--- a/search.c
+++ b/search.c
@@ -1366,7 +1366,7 @@ void do_search_string(EditState *s, const char *search_str, int mode)
     }
     if (mode == CMD_LIST_MATCHING_LINES) {
         // XXX: should check prefix argument to clear buffer
-        b1 = qe_new_buffer(s->qs, "*occur*", BC_REUSE | BF_UTF8 | (s->b->flags & BF_STYLES));
+        b1 = qe_new_buffer(s->qs, "*occur*", BF_UTF8 | (s->b->flags & BF_STYLES));
         if (!b1)
             return;
         start = b1->total_size;

--- a/search.c
+++ b/search.c
@@ -1365,8 +1365,9 @@ void do_search_string(EditState *s, const char *search_str, int mode)
         last = eb_goto_bol(s->b, offset);
     }
     if (mode == CMD_LIST_MATCHING_LINES) {
+        do_kill_buffer(s, "*occur*", 1);
         // XXX: should check prefix argument to clear buffer
-        b1 = qe_new_buffer(s->qs, "*occur*", BF_UTF8 | (s->b->flags & BF_STYLES));
+        b1 = qe_new_buffer(s->qs, "*occur*", BC_REUSE | BF_UTF8 | (s->b->flags & BF_STYLES));
         if (!b1)
             return;
         start = b1->total_size;

--- a/search.c
+++ b/search.c
@@ -1366,8 +1366,7 @@ void do_search_string(EditState *s, const char *search_str, int mode)
     }
     if (mode == CMD_LIST_MATCHING_LINES) {
         do_kill_buffer(s, "*occur*", 1);
-        // XXX: should check prefix argument to clear buffer
-        b1 = qe_new_buffer(s->qs, "*occur*", BC_REUSE | BF_UTF8 | (s->b->flags & BF_STYLES));
+        b1 = qe_new_buffer(s->qs, "*occur*", BF_UTF8 | (s->b->flags & BF_STYLES));
         if (!b1)
             return;
         start = b1->total_size;


### PR DESCRIPTION
When I use the `occur` command, it shows a matching list of the search pattern. When I use it to search another string, it still shows the previous result.

## How to reproduce
1. `M-x occur` to search a string `str1` and it shows the result
2. Use `C-g` to hide the `*occur*` buffer
3. Use `M-x occur` again to search another string `str2`, it still shows the `str1` result

## My solution

I think there are two possible solutions.
Solution 1. We just remove the `BC_REUSE` flag. Then it will create new buffers like `*occur-1*`, `*occur-2*`
Solution 2. Before we create the `*occur*` buffer, we just kill the current `*occur*` buffer.

I think both of them are acceptable. Considering GNU Emacs uses the second behavior, so I choose the second one.