### PR TITLE
fix man command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-<!-- TODO list for qemacs -- Author: Charlie Gordon -- Updated: 2025-02-10 -->
+<!-- TODO list for qemacs -- Author: Charlie Gordon -- Updated: 2025-05-17 -->
 
 # QEmacs TODO list
 
@@ -672,7 +672,6 @@ insert_window_left()  deletes some left-most windows
 
 ### Shell mode
 
-* fix `man` command on linux: the man process should be given the expected input
 * parse the list of errors and register line/column positions so buffer can be modified
     using this array, implement skip to the errors in the next file with `C-u C-x C-n`
 * [BUG] ^C does not work on OpenBSD
@@ -683,12 +682,9 @@ insert_window_left()  deletes some left-most windows
 * `C-c C-c` should abort make process and other shell buffers
 * support `:` as alternate escape sequence argument separator
 * `start-shell` should kill popup window
-* `A-x kill-buffer RET` -> hang
-* turn on interactive mode on commands that move the cursor to EOB
 * use auxiliary buffer to make process input asynchronous
 * give commands a chance to execute for macros to behave correctly
 * `A-y` at process prompt
-* fix very long lines in shell buffer (not finished)
 * fix screen size notifications, `SIGWINCH` signals and ioctl
 * fix terminal size inside shell window ?
 * other buffer modification functions in shell input region
@@ -701,9 +697,6 @@ insert_window_left()  deletes some left-most windows
   key sequence to allow typing special keys into shell process
 * cmdline arg to force lines and columns to test shell.
 * toggling interactive shell mode is not automatic enough
-* use target window for man and similar commands
-* fix infinite scroll for man command
-* man output bug on linux
 * man pager -> more bindings, such as `RET` -> `push-button` (jump to map page)
 * cross link man pages
 * accented letter input in shell mode

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -230,6 +230,10 @@ static int run_process(ShellState *s,
     }
     fcntl(pty_fd, F_SETFL, O_NONBLOCK);
 
+    if (shell_flags & SF_INFINITE) {
+        rows += QE_TERM_YSIZE_INFINITE;
+    }
+
     /* set dummy screen size */
     ws.ws_col = cols;
     ws.ws_row = rows;
@@ -284,20 +288,9 @@ static int run_process(ShellState *s,
 #ifdef CONFIG_DARWIN
         setsid();
 #endif
-        if (shell_flags & SF_INFINITE) {
-            rows += QE_TERM_YSIZE_INFINITE;
-        }
         snprintf(lines_string, sizeof lines_string, "%d", rows);
         snprintf(columns_string, sizeof columns_string, "%d", cols);
 
-        // XXX: should prevent less from paging:
-        //      update the terminal size because
-        //         ioctl TIOCGWINSZ or WIOCGETD take precedence
-        //         over LINES and COLUMNS in linux
-        //      MANWIDTH overrides COLUMNS and ioctl stuff?
-        //      MAN_KEEP_FORMATING count be used
-        //      "PAGER=less -E -z1000" does not seem to work
-        //      "LESS=-E -z1000" does not work either
         setenv("LINES", lines_string, 1);
         setenv("COLUMNS", columns_string, 1);
         setenv("TERM", "xterm-256color", 1);
@@ -2815,8 +2808,11 @@ static void do_man(EditState *s, const char *arg)
         s->qs->active_window = s;
     }
 
-    /* Assume standard man command */
-    snprintf(cmd, sizeof(cmd), "man %s", arg);
+    // LESS_LINES Sets the number of lines on the screen and takes
+    // precedence over the system's idea of the screen size.
+    // -F makes less quit automatically when output fits the screen.
+    snprintf(cmd, sizeof(cmd), "LESS_LINES='%d' MANPAGER='less -F' man %s",
+             QE_TERM_YSIZE_INFINITE, arg);
 
     snprintf(bufname, sizeof(bufname), "*Man %s*", arg);
     if (try_show_buffer(&s, bufname))


### PR DESCRIPTION
I guess man command was intended to be run non-interactively as when creating a new buffer for man  command 

    /* create new buffer */
    b = qe_new_shell_buffer(s->qs, NULL, s, bufname, NULL,
                            NULL, cmd, SF_COLOR | SF_INFINITE);

SF_INTERACTIVE flag is not used however using `man %s ` to invoke the command forced to use the pager.