### PR TITLE
fix: encode non-printable characters in filenames and buffer names

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2367,6 +2367,13 @@ int eb_puts(EditBuffer *b, const char *s) {
     return eb_insert_utf8_buf(b, b->offset, s, strlen(s));
 }
 
+int eb_puts_quoted_filename(EditBuffer *b, const char *s) {
+    char buf[MAX_FILENAME_SIZE * 4];
+
+    qe_quote_filename(buf, sizeof(buf), s);
+    return eb_puts(b, buf);
+}
+
 int eb_vprintf(EditBuffer *b, const char *fmt, va_list ap) {
     char buf0[1024];
     char *buf;

--- a/modes/bufed.c
+++ b/modes/bufed.c
@@ -127,6 +127,37 @@ static int bufed_sort_func(void *opaque, const void *p1, const void *p2)
     return (sort_mode & BUFED_SORT_DESCENDING) ? -res : res;
 }
 
+#define BUFED_NAME_WIDTH  20
+#define BUFED_NAME_TAIL   5
+
+static int bufed_put_buffer_name(EditBuffer *b, const char *name) {
+    /* Truncate the raw name before quoting so escape sequences are not
+       split in the displayed buffer list.  Escaped control bytes may
+       still expand the displayed text beyond BUFED_NAME_WIDTH. */
+    int len = strlen(name);
+
+    if (len > BUFED_NAME_WIDTH) {
+        enum { HEAD = BUFED_NAME_WIDTH - BUFED_NAME_TAIL - 3 };
+        char head[HEAD + 1];
+        char tail[BUFED_NAME_TAIL + 1];
+        char qhead[HEAD * 4 + 1];
+        char qtail[BUFED_NAME_TAIL * 4 + 1];
+
+        memcpy(head, name, HEAD);
+        head[HEAD] = '\0';
+        memcpy(tail, name + len - BUFED_NAME_TAIL, BUFED_NAME_TAIL);
+        tail[BUFED_NAME_TAIL] = '\0';
+        qe_quote_filename(qhead, sizeof(qhead), head);
+        qe_quote_filename(qtail, sizeof(qtail), tail);
+        return eb_printf(b, "%s...%s", qhead, qtail);
+    } else {
+        char qname[MAX_BUFFERNAME_SIZE * 4];
+
+        qe_quote_filename(qname, sizeof(qname), name);
+        return eb_printf(b, "%-*s", BUFED_NAME_WIDTH, qname);
+    }
+}
+
 static void build_bufed_list(EditState *s, BufedState *bs)
 {
     QEmacsState *qs = s->qs;
@@ -167,7 +198,7 @@ static void build_bufed_list(EditState *s, BufedState *bs)
     for (i = 0; i < bs->items.nb_items; i++) {
         char flags[4];
         char *flagp = flags;
-        int len, style0;
+        int style0;
 
         item = bs->items.items[i];
         b1 = qe_check_buffer(qs, (EditBuffer**)(void *)&item->opaque);
@@ -193,17 +224,10 @@ static void build_bufed_list(EditState *s, BufedState *bs)
         b->cur_style = style0;
         eb_printf(b, " %-2s", flags);
         b->cur_style = BUFED_STYLE_BUFNAME;
-        len = strlen(item->str);
-        /* simplistic column fitting, does not work for wide characters */
-#define COLWIDTH  20
-        if (len > COLWIDTH) {
-            eb_printf(b, "%.*s...%s",
-                      COLWIDTH - 5 - 3, item->str, item->str + len - 5);
-        } else {
-            eb_printf(b, "%-*s", COLWIDTH, item->str);
-        }
+        bufed_put_buffer_name(b, item->str);
         if (b1) {
             char path[MAX_FILENAME_SIZE];
+            char qpath[MAX_FILENAME_SIZE * 4];
             char mode_buf[64];
             const char *mode_name;
             buf_t outbuf, *out;
@@ -248,7 +272,8 @@ static void build_bufed_list(EditState *s, BufedState *bs)
             } else {
                 make_user_path(path, sizeof(path), b1->filename);
             }
-            eb_puts(b, path);
+            qe_quote_filename(qpath, sizeof(qpath), path);
+            eb_puts(b, qpath);
             b->cur_style = style0;
         }
         eb_putc(b, '\n');

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -870,7 +870,7 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
         b->cur_style = DIRED_STYLE_HEADER;
         eb_puts(b, "  Directory of ");
         b->cur_style = DIRED_STYLE_DIRECTORY;
-        eb_puts(b, ds->path);
+        eb_puts_quoted_filename(b, ds->path);
         b->cur_style = DIRED_STYLE_HEADER;
         eb_puts(b, "\n  ");
         if (ds->ndirs) {
@@ -939,7 +939,7 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
         else
             b->cur_style = DIRED_STYLE_FILENAME;
 
-        eb_puts(b, fname);
+        eb_puts_quoted_filename(b, fname);
 
         if (*fname != '/' || fname[1]) {
             int trailchar = get_trailchar(dip->mode);
@@ -949,7 +949,8 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
         }
         if (S_ISLNK(dip->mode)
         &&  getentryslink(buf, sizeof(buf), dip->fullname)) {
-            eb_printf(b, " -> %s", buf);
+            eb_puts(b, " -> ");
+            eb_puts_quoted_filename(b, buf);
         }
         b->cur_style = DIRED_STYLE_NORMAL;
         eb_putc(b, '\n');
@@ -1943,7 +1944,7 @@ int file_print_entry(CompleteState *cp, EditState *s, const char *name) {
 
     if (!stat(name, &st)) {
         b->cur_style = S_ISDIR(st.st_mode) ? DIRED_STYLE_DIRECTORY : DIRED_STYLE_FILENAME;
-        len = eb_puts(b, name);
+        len = eb_puts_quoted_filename(b, name);
         b->tab_width = max3_int(16, 2 + len, b->tab_width);
         b->cur_style = DIRED_STYLE_NORMAL;
         format_size(buf, sizeof(buf), dired_hflag, st.st_mode, st.st_dev, st.st_size);
@@ -1957,7 +1958,7 @@ int file_print_entry(CompleteState *cp, EditState *s, const char *name) {
         len += eb_printf(b, "  %-*s", gidlen, buf);
         len += eb_printf(b, "  %*d", linklen, (int)st.st_nlink);
     } else {
-        return eb_puts(b, name);
+        return eb_puts_quoted_filename(b, name);
     }
     return len;
 }

--- a/qe.c
+++ b/qe.c
@@ -3377,6 +3377,7 @@ static char *qe_get_mode_name(EditState *s, char *buf, int size, int full)
 void basic_mode_line(EditState *s, buf_t *out, int c1)
 {
     char buf[128];
+    char name[MAX_BUFFERNAME_SIZE * 4];
     const char *mode_name;
     int mod, state;
 
@@ -3393,10 +3394,11 @@ void basic_mode_line(EditState *s, buf_t *out, int c1)
     mode_name = qe_get_mode_name(s, buf, sizeof(buf), 1);
     /* Strip text mode name if another mode is also active */
     strstart(mode_name, "text ", &mode_name);
+    qe_quote_filename(name, sizeof(name), s->b->name);
 
     buf_printf(out, "%c%c:%c%c  %-20s  (%s)",
                c1, state, s->b->flags & BF_READONLY ? '%' : mod,
-               mod, s->b->name, mode_name);
+               mod, name, mode_name);
 }
 
 void text_mode_line(EditState *s, buf_t *out)
@@ -7353,12 +7355,15 @@ void file_complete(CompleteState *cp, CompleteFunc enumerate)
     find_file_close(&ffst);
 }
 
+static int quoted_completion_window_get_entry(EditState *s, char *dest, int size, int offset);
+
 static CompletionDef file_completion = {
     .name = "file",
     .enumerate = file_complete,
 #ifndef CONFIG_TINY
     .print_entry = file_print_entry,
 #endif
+    .get_entry = quoted_completion_window_get_entry,
     .flags = CF_FILENAME,
 };
 
@@ -7367,6 +7372,7 @@ static CompletionDef dir_completion = {
     .name = "dir",
     .enumerate = file_complete,
     .print_entry = file_print_entry,
+    .get_entry = quoted_completion_window_get_entry,
     .flags = CF_DIRNAME | CF_NO_FUZZY,
 };
 
@@ -7374,6 +7380,7 @@ static CompletionDef resource_completion = {
     .name = "resource",
     .enumerate = file_complete,
     .print_entry = file_print_entry,
+    .get_entry = quoted_completion_window_get_entry,
     .flags = CF_RESOURCE | CF_NO_FUZZY,
 };
 #endif
@@ -7397,16 +7404,16 @@ static int buffer_print_entry(CompleteState *cp, EditState *s, const char *name)
 
     if (b1) {
         b->cur_style = QE_STYLE_KEYWORD;
-        len = eb_puts(b, b1->name);
+        len = eb_puts_quoted_filename(b, b1->name);
         b->tab_width = max3_int(16, 2 + len, b->tab_width);
         len += eb_putc(b, '\t');
         if (*b1->filename) {
             b->cur_style = QE_STYLE_COMMENT;
-            len += eb_puts(b, b1->filename);
+            len += eb_puts_quoted_filename(b, b1->filename);
         }
         b->cur_style = QE_STYLE_DEFAULT;
     } else {
-        return eb_puts(b, name);
+        return eb_puts_quoted_filename(b, name);
     }
     return len;
 }
@@ -7415,6 +7422,7 @@ static CompletionDef buffer_completion = {
     .name = "buffer",
     .enumerate = buffer_complete,
     .print_entry = buffer_print_entry,
+    .get_entry = quoted_completion_window_get_entry,
 };
 
 static int default_completion_window_print_entry(CompleteState *cp, EditState *s, const char *name) {
@@ -7428,6 +7436,13 @@ static int default_completion_window_get_entry(EditState *s, char *dest, int siz
         len = p - dest;
     dest[len] = '\0';   /* strip the TAB or trailing newline if any */
     return len;
+}
+
+static int quoted_completion_window_get_entry(EditState *s, char *dest, int size, int offset) {
+    char buf[MAX_FILENAME_SIZE * 4 + 1];
+
+    default_completion_window_get_entry(s, buf, sizeof(buf), offset);
+    return qe_unquote_filename(dest, size, buf);
 }
 
 static int completion_sort_func(const void *p1, const void *p2)

--- a/qe.h
+++ b/qe.h
@@ -589,6 +589,7 @@ int eb_match_istr_utf8(EditBuffer *b, int offset, const char *str, int *offsetp)
 int eb_vprintf(EditBuffer *b, const char *fmt, va_list ap) qe__attr_printf(2,0);
 int eb_printf(EditBuffer *b, const char *fmt, ...) qe__attr_printf(2,3);
 int eb_puts(EditBuffer *b, const char *s);
+int eb_puts_quoted_filename(EditBuffer *b, const char *s);
 int eb_putc(EditBuffer *b, char32_t c);
 
 void eb_line_pad(EditBuffer *b, int offset, int n);

--- a/util.c
+++ b/util.c
@@ -2275,6 +2275,114 @@ int strquote(char *dest, int size, const char *str, int len) {
     return out->pos;
 }
 
+int qe_quote_filename(char *dest, int size, const char *str) {
+    /*@API utils.string
+       Quote a filename or buffer name for display in UI text.
+       @argument `dest` a valid pointer to an array of bytes
+       @argument `size` the length of the destination array
+       @argument `str` a valid pointer to a filename or buffer name
+       @return the length of the converted string, not counting the null
+       terminator, possibly longer than the destination array length.
+       @note This uses ls -b style escapes so line- and tab-oriented UI
+       buffers remain parseable.  The stored filename/buffer name remains
+       unchanged.
+     */
+    buf_t outbuf, *out;
+    const unsigned char *p = (const unsigned char *)str;
+
+    out = buf_init(&outbuf, dest, size);
+    while (*p) {
+        unsigned char ch = *p++;
+
+        switch (ch) {
+        case '\n':
+            buf_puts(out, "\\n");
+            break;
+        case '\t':
+            buf_puts(out, "\\t");
+            break;
+        case '\r':
+            buf_puts(out, "\\r");
+            break;
+        case '\b':
+            buf_puts(out, "\\b");
+            break;
+        case '\f':
+            buf_puts(out, "\\f");
+            break;
+        case '\\':
+            buf_puts(out, "\\\\");
+            break;
+        default:
+            if (ch < 32 || ch == 127) {
+                buf_printf(out, "\\%03o", ch);
+            } else {
+                buf_put_byte(out, ch);
+            }
+            break;
+        }
+    }
+    return out->pos;
+}
+
+int qe_unquote_filename(char *dest, int size, const char *str) {
+    /*@API utils.string
+       Decode strings produced by qe_quote_filename().
+       @argument `dest` a valid pointer to an array of bytes
+       @argument `size` the length of the destination array
+       @argument `str` a valid pointer to a quoted filename or buffer name
+       @return the length of the converted string, not counting the null
+       terminator, possibly longer than the destination array length.
+       @note Unknown escape sequences are reduced to their escaped character,
+       matching the common behavior needed for ls -b style names.
+     */
+    buf_t outbuf, *out;
+    const unsigned char *p = (const unsigned char *)str;
+
+    out = buf_init(&outbuf, dest, size);
+    while (*p) {
+        unsigned char ch = *p++;
+
+        if (ch == '\\' && *p) {
+            ch = *p++;
+            switch (ch) {
+            case 'n':
+                ch = '\n';
+                break;
+            case 't':
+                ch = '\t';
+                break;
+            case 'r':
+                ch = '\r';
+                break;
+            case 'b':
+                ch = '\b';
+                break;
+            case 'f':
+                ch = '\f';
+                break;
+            case '\\':
+                break;
+            default:
+                if (ch >= '0' && ch <= '7') {
+                    int n = ch - '0';
+                    int i;
+
+                    for (i = 1; i < 3 && *p >= '0' && *p <= '7'; i++) {
+                        n = n * 8 + *p++ - '0';
+                    }
+                    ch = n & 255;
+                } else {
+                    buf_put_byte(out, '\\');
+                }
+                break;
+            }
+        }
+        buf_put_byte(out, ch);
+    }
+    return out->pos;
+}
+
 #if 0
 /* TODO */
 int strunquote(char *dest, int size, const char *str, int len)

--- a/util.h
+++ b/util.h
@@ -405,6 +405,8 @@ int strsubst(char *buf, int buf_size, const char *from,
 int byte_quote(char *dest, int size, unsigned char c);
 int strquote(char *dest, int size, const char *str, int len);
 int strunquote(char *dest, int size, const char *str, int len);
+int qe_quote_filename(char *dest, int size, const char *str);
+int qe_unquote_filename(char *dest, int size, const char *str);
 
 /*---- Unicode string functions ----*/
 


### PR DESCRIPTION
**Fix: Prevent UI breakage from unprintable characters in filenames and buffer names**

<img width="1650" height="558" alt="ScreenShot_2026-05-02_001752_145" src="https://github.com/user-attachments/assets/cc364d02-84c6-4a10-a477-17bbb1100224" />

**Problem:**
Non-printable characters in filenames and buffer names break the UI layout. Examples:
- dired: Newlines (`\n`) cause single files to span multiple lines.
- Completion popups: Tabs (`\t`) break field parsing.
- mode line / bufed: Control characters make buffer names unreadable.

<img width="1743" height="585" alt="ScreenShot_2026-05-02_153518_220" src="https://github.com/user-attachments/assets/fd6fb9a9-df08-4a55-a6ad-3248a9908978" />


**Solution:**
Keep raw filenames/buffer names internally (file operations and caching logic remain unchanged). Reversibly escape these names *only* when displaying them in the UI. Unescape them back to raw values upon user selection.

**Changes:**
- Added `qe_quote_filename()` / `qe_unquote_filename()` using `ls -b` style escaping:
  - `\n`, `\t`, `\r`, `\b`, `\f`
  - `\\`
  - `\NNN` (3-digit octal) for other control bytes and `DEL`.
- dired: Display quoted text for dir names, filenames, and symlink targets.
- Completion popups: Display quoted text; unquote upon selection.
- mode line: Display quoted buffer names.
- bufed: Display quoted buffer names and paths. Long names are truncated *before* quoting to avoid splitting escape sequences.
- Unquoting fallback: Keep unknown escapes as-is to prevent losing valid backslashes.

**Known Limitations:**
- bufed alignment: Column widths still rely on raw bytes. Quoted control characters might stretch the display beyond 20 columns (similar to current UTF-8/wide char behavior).
- Completion alignment: Tab alignment uses quoted byte length, not visual width. This may push columns slightly right, but functionality is unaffected.
- Future UI: Any new UI components outputting filenames/buffer names must explicitly use the quote helper.

---

This is currently just an attempted fix.