### PR TITLE
Fix compile warning on macOS

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -845,7 +845,7 @@ static inline void qe__list_del(struct list_head *prev, struct list_head *next)
     next->prev = prev;
 }
 
-#define LIST_HEAD(name) struct list_head name = { &name, &name }
+#define LIST_HEAD_INIT(name) struct list_head name = { &name, &name }
 
 /* add at the head */
 #define list_add(elem, head) \

--- a/cutils.h
+++ b/cutils.h
@@ -845,7 +845,7 @@ static inline void qe__list_del(struct list_head *prev, struct list_head *next)
     next->prev = prev;
 }
 
-#define LIST_HEAD_INIT(name) struct list_head name = { &name, &name }
+#define QE_LIST_HEAD(name) struct list_head name = { &name, &name }
 
 /* add at the head */
 #define list_add(elem, head) \

--- a/unix.c
+++ b/unix.c
@@ -69,8 +69,8 @@ static int url_fdmax;
 static URLHandler url_handlers[256];
 static int url_exit_request;
 static int url_display_request;
-static LIST_HEAD_INIT(pid_handlers);
-static LIST_HEAD_INIT(bottom_halves);
+static QE_LIST_HEAD(pid_handlers);
+static QE_LIST_HEAD(bottom_halves);
 static QETimer *first_timer;
 
 

--- a/unix.c
+++ b/unix.c
@@ -69,8 +69,8 @@ static int url_fdmax;
 static URLHandler url_handlers[256];
 static int url_exit_request;
 static int url_display_request;
-static LIST_HEAD(pid_handlers);
-static LIST_HEAD(bottom_halves);
+static LIST_HEAD_INIT(pid_handlers);
+static LIST_HEAD_INIT(bottom_halves);
 static QETimer *first_timer;
 
 


### PR DESCRIPTION
Rename the macro `LIST_HEAD` since it is already defined in macOS 14.6.1

```
In file included from ./util.h:29:
./cutils.h:848:9: warning: 'LIST_HEAD' macro redefined [-Wmacro-redefined]
  848 | #define LIST_HEAD(name) struct list_head name = { &name, &name }
      |         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/queue.h:465:9: note: previous definition is here
  465 | #define LIST_HEAD(name, type)                                           \
      |         ^
1 warning generated.
```
