### PR TITLE
occur: reuse the same buffer but clear contents

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -701,7 +701,7 @@ EditBuffer *qe_new_buffer(QEmacsState *qs, const char *name, int flags)
     EditBuffer *b;
     EditBuffer **pb;
 
-    if (flags & BC_REUSE) {
+    if (flags & (BC_REUSE | BC_CLEAR)) {
         b = qe_find_buffer_name(qs, name);
         if (b != NULL) {
             if (flags & BC_CLEAR)

--- a/extras.c
+++ b/extras.c
@@ -1392,7 +1392,7 @@ static void do_about_qemacs(EditState *s)
     const CmdDef *d;
     int start, stop, i, j;
 
-    b = qe_new_buffer(qs, "*About QEmacs*", BC_REUSE | BC_CLEAR | BF_UTF8);
+    b = qe_new_buffer(qs, "*About QEmacs*", BC_CLEAR | BF_UTF8);
     if (!b)
         return;
 
@@ -2634,8 +2634,7 @@ static void do_list_colors(EditState *s, int argval) {
     char buf[32];
     int i;
 
-    b = qe_new_buffer(s->qs, "*Colors*",
-                      BC_REUSE | BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE8);
+    b = qe_new_buffer(s->qs, "*Colors*", BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE8);
     if (!b)
         return;
 

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -1329,7 +1329,7 @@ static void do_c_list_conditionals(EditState *s)
     int offset, offset1;
     EditBuffer *b;
 
-    b = qe_new_buffer(s->qs, "Preprocessor conditionals", BC_REUSE | BC_CLEAR | BF_UTF8);
+    b = qe_new_buffer(s->qs, "Preprocessor conditionals", BC_CLEAR | BF_UTF8);
     if (!b)
         return;
 

--- a/modes/bufed.c
+++ b/modes/bufed.c
@@ -398,7 +398,7 @@ static void do_buffer_list(EditState *s, int argval)
         qs->active_window = s;
     }
 
-    b = qe_new_buffer(qs, "*bufed*", BC_REUSE | BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE1);
+    b = qe_new_buffer(qs, "*bufed*", BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE1);
     if (!b)
         return;
 

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -1680,7 +1680,7 @@ void do_dired_path(EditState *s, const char *filename)
             goto new_window;
         }
     }
-    b = qe_new_buffer(qs, "*dired*", BC_REUSE | BC_CLEAR | BF_READONLY | BF_UTF8);
+    b = qe_new_buffer(qs, "*dired*", BC_CLEAR | BF_READONLY | BF_UTF8);
     if (!b)
         return;
 

--- a/modes/fractal.c
+++ b/modes/fractal.c
@@ -1228,7 +1228,7 @@ static void do_mandelbrot_test(EditState *s, int argval) {
     }
 
     // XXX: should handle multiple Mandelbrot sets for comparison
-    b = qe_new_buffer(qs, "*Mandelbrot*", BC_REUSE | BC_CLEAR | BF_UTF8 | BF_STYLE4);
+    b = qe_new_buffer(qs, "*Mandelbrot*", BC_CLEAR | BF_UTF8 | BF_STYLE4);
     if (!b)
         return;
 

--- a/qe.c
+++ b/qe.c
@@ -10058,7 +10058,7 @@ void do_save_session(EditState *s, int popup)
     EditBuffer *b;
     time_t now;
 
-    b = qe_new_buffer(s->qs, "*session*", BC_REUSE | BC_CLEAR | BF_UTF8);
+    b = qe_new_buffer(s->qs, "*session*", BC_CLEAR | BF_UTF8);
     if (!b)
         return;
 
@@ -10125,7 +10125,7 @@ void do_describe_key_briefly(EditState *s, const char *keystr, int argval) {
 
 EditBuffer *new_help_buffer(EditState *s)
 {
-    return qe_new_buffer(s->qs, "*Help*", BC_REUSE | BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE1);
+    return qe_new_buffer(s->qs, "*Help*", BC_CLEAR | BF_SYSTEM | BF_UTF8 | BF_STYLE1);
 }
 
 void do_help_for_help(EditState *s)

--- a/qe.h
+++ b/qe.h
@@ -380,7 +380,7 @@ typedef struct EditBufferDataType {
 #define BF_SHELL    0x20000  /* buffer is a shell buffer */
 /* buffer creation flags */
 #define BC_REUSE   0x100000  /* reuse existing buffer with same name */
-#define BC_CLEAR   0x200000  /* erase found buffer with same name */
+#define BC_CLEAR   0x200000  /* reuse existing buffer and clear it */
 
 struct EditBuffer {
     OWNED Page *page_table;

--- a/search.c
+++ b/search.c
@@ -1365,8 +1365,7 @@ void do_search_string(EditState *s, const char *search_str, int mode)
         last = eb_goto_bol(s->b, offset);
     }
     if (mode == CMD_LIST_MATCHING_LINES) {
-        do_kill_buffer(s, "*occur*", 1);
-        b1 = qe_new_buffer(s->qs, "*occur*", BF_UTF8 | (s->b->flags & BF_STYLES));
+        b1 = qe_new_buffer(s->qs, "*occur*", BC_CLEAR | BF_UTF8 | (s->b->flags & BF_STYLES));
         if (!b1)
             return;
         start = b1->total_size;


### PR DESCRIPTION
* use `BC_REUSE | BC_CLEAR` to avoid killing the `*occur*` buffer
* this ensures the `*occur*` buffer stays current in windows that show it
* modify the `BC_CLEAR` semantics to imply `BC_REUSE`
* simplify calls: remove redundant `BC_REUSE` flag