### PR TITLE
navigation: improve forward-block / backward-block

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2524,7 +2524,7 @@ int eb_insert_buffer_convert(EditBuffer *dest, int dest_offset,
 }
 
 int eb_get_line(EditBuffer *b, char32_t *buf, int size,
-                int offset, int *offset_ptr)
+                int offset, int *offset_ptr /* nullable */)
 {
     /*@API buffer
        Get contents of the line starting at offset `offset` as an array of
@@ -2534,12 +2534,14 @@ int eb_get_line(EditBuffer *b, char32_t *buf, int size,
        @argument `size` the length of the destination array
        @argument `offset` the offset in bytes of the beginning of the line in
        the buffer
-       @argument `offset_ptr` a pointer to a variable to receive the offset
-       of the first unread character in the buffer.
+       @argument `offset_ptr` a nullable pointer to a variable to receive the
+       offset of the first unread character in the buffer
        @returns the number of codepoints stored into the destination array
        before the newline if any.
        @note: the return value `len` verifies `len >= 0` and `len < buf_size`.
        If a complete line was read, `buf[len] == '\n'` and `buf[len + 1] == '\0'`.
+       A newline is stored at `buf[len]` even if at end of buffer without a trailing
+       newline.
        Truncation can be detected by checking `buf[len] != '\n'` or `len < buf_size - 1`.
      */
     int len = 0;
@@ -2567,7 +2569,7 @@ int eb_get_line(EditBuffer *b, char32_t *buf, int size,
     return len;
 }
 
-int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr)
+int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr /* nullable */)
 {
     /*@API buffer
        Get the length in codepoints of the line starting at offset `offset`
@@ -2576,8 +2578,8 @@ int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr)
        @argument `b` a valid pointer to an `EditBuffer`
        @argument `offset` the offset in bytes of the beginning of the line in
        the buffer
-       @argument `offset_ptr` a pointer to a variable to receive the offset
-       of the first unread character in the buffer.
+       @argument `offset_ptr` a nullable pointer to a variable to receive the
+       offset of the first unread character in the buffer.
        @returns the number of codepoints in the line including the newline if any.
      */
     int len = 0;
@@ -2601,8 +2603,8 @@ int eb_fgets(EditBuffer *b, char *buf, int size,
        @argument `size` the length of the destination array
        @argument `offset` the offset in bytes of the beginning of the line in
        the buffer
-       @argument `offset_ptr` a pointer to a variable to receive the offset
-       of the first unread character in the buffer.
+       @argument `offset_ptr` a nullable pointer to a variable to receive the
+       offset of the first unread character in the buffer
        @returns the number of bytes stored into the destination array before
        the newline if any. No partial encoding is stored into the array.
        @note: the return value `len` verifies `len >= 0` and `len < buf_size`.

--- a/extras.c
+++ b/extras.c
@@ -144,9 +144,7 @@ static int qe_skip_style(EditState *s, int offset, int *offsetp, QETermStyle sty
     eb_get_pos(s->b, &line_num, &col_num, offset);
     offset0 = eb_goto_bol2(s->b, offset, &pos);
     len = get_colorized_line(cp, offset0, &offset1, line_num);
-    if (len > cp->buf_size)
-        len = cp->buf_size;
-    if (pos >= len ||cp->sbuf[pos] != style) {
+    if (pos >= len || cp->sbuf[pos] != style) {
         cp_destroy(cp);
         return 0;
     }
@@ -793,8 +791,7 @@ static void do_indent_region(EditState *s, int start, int end, int argval)
     /* Iterate over all lines inside block */
     for (line = line1; line <= line2; line++) {
         int offset = eb_goto_pos(s->b, line, 0);
-        int off1;
-        if (eb_nextc(s->b, offset, &off1) != '\n')
+        if (eb_peekc(s->b, offset) != '\n')
             (s->mode->indent_func)(s, offset);
     }
 }
@@ -824,57 +821,89 @@ static char32_t matching_delimiter(char32_t c) {
     return c;
 }
 
+static int style_normalize(int style) {
+    // XXX: if style is absolute color, try and match comment and string color
+    switch (style) {
+    case QE_STYLE_COMMENT:
+        return QE_STYLE_COMMENT;
+    case QE_STYLE_STRING:
+    case QE_STYLE_STRING_Q:
+        return QE_STYLE_STRING;
+    }
+    return 0;
+}
+
 static void forward_block(EditState *s, int dir)
 {
+    // We skip characters, balancing blocks delimited by (){}[]
+    // * we use the colorizer to determine the token type.
+    // * If starting in a string of in a comment, we stop at the end of the
+    //   string or comment, allowing for non colored whitespace.
+    // * otherwise, we skip comments and strings
+    // * block delimiters are balanced inside the region and skipping stops
+    //   when a closing delimiter is found.
+    // if a nesting error occurs, point and mark are set around the mismatched
+    //   delimiters. use C-x C-x to skip between them
+
     QEColorizeContext cp[1];
     char32_t balance[MAX_LEVEL];
-    int use_colors;
-    int line_num, col_num, style, style0, level;
-    int pos;      /* position of the current character on line */
-    int len;      /* number of colorized positions */
-    int offset;   /* offset of the current character */
-    int offset0;  /* offset of the beginning of line */
-    int offset1;  /* offset of the beginning of the next line */
+    int delim_offset[MAX_LEVEL];
+    int line_num, col_num;
+    int use_colors; /* set if using styles from colorizer */
+    int level;      /* block nesting level */
+    int style;      /* style of current character */
+    int style0;     /* style of the starting point */
+    int pos;        /* index of the current character on line */
+    int len;        /* number of colorized positions */
+    int offset;     /* offset of the current character */
+    int bol_offset; /* offset of the beginning of line */
+    int pending_offset; /* end of string or comment if skipping whitespace */
+    int dummy_offset;
     char32_t c;
 
     cp_initialize(cp, s);
 
     offset = s->offset;
     eb_get_pos(s->b, &line_num, &col_num, offset);
-    offset1 = offset0 = eb_goto_bol2(s->b, offset, &pos);
+    bol_offset = eb_goto_bol2(s->b, offset, &pos);
     use_colors = s->colorize_mode || s->b->b_styles;
+    pending_offset = -1;
     style0 = 0;
     len = 0;
     if (use_colors) {
-        len = get_colorized_line(cp, offset1, &offset1, line_num);
-        if (len < cp->buf_size - 2) {
-            if (pos > 0
-            &&  ((c = cp->buf[pos - 1]) == ']' || c == '}' || c == ')')) {
-                style0 = cp->sbuf[pos - 1];
-            } else
-            if (pos < len) {
-                style0 = cp->sbuf[pos];
-            }
-        } else {
-            /* very long line detected, use fallback version */
+        len = get_colorized_line(cp, bol_offset, &dummy_offset, line_num);
+        if (cp->truncated) {
+            /* very long line detected, do not use styles */
             use_colors = 0;
             len = 0;
+        } else {
+            if (dir < 0) {
+                if (pos <= len)
+                    style0 = style_normalize(cp->sbuf[pos - (pos > 0)]);
+            } else {
+                if (pos < len) {
+                    style0 = style_normalize(cp->sbuf[pos]);
+                } else {
+                    // XXX if point is at end of line, should check if inside a block of comments or strings
+                }
+            }
         }
     }
     level = 0;
 
     if (dir < 0) {
         for (;;) {
+            int this_offset = offset;
             c = eb_prevc(s->b, offset, &offset);
             if (c == '\n') {
                 if (offset <= 0)
                     break;
                 line_num--;
-                offset1 = offset0 = eb_goto_bol2(s->b, offset, &pos);
+                bol_offset = eb_goto_bol2(s->b, offset, &pos);
                 len = 0;
                 if (use_colors) {
-                    len = get_colorized_line(cp, offset1, &offset1, line_num);
-                    if (len >= cp->buf_size - 2) {
+                    len = get_colorized_line(cp, bol_offset, &dummy_offset, line_num);
+                    if (cp->truncated) {
                         /* very long line detected, use fallback version */
                         use_colors = 0;
                         len = 0;
@@ -883,29 +912,47 @@ static void forward_block(EditState *s, int dir)
                 }
                 continue;
             }
+            pos--;
+            if (qe_isspace(c))
+                continue;
             style = 0;
-            --pos;
-            if (pos >= 0 && pos < len) {
-                style = cp->sbuf[pos];
+            if (use_colors) {
+                if (pos >= 0 && pos < len) {
+                    style = style_normalize(cp->sbuf[pos]);
+                }
+                if (style != style0) {
+                    if (style0 == 0) {
+                        // skip string or comment
+                        continue;
+                    }
+                    // stop at end of string or comment
+                    break;
+                }
             }
-            if (style != style0 && style != QE_STYLE_KEYWORD && style != QE_STYLE_FUNCTION) {
-                if (style0 == 0)
-                    continue;
-                style0 = 0;
-                if (style != 0)
-                    continue;
-            }
+            pending_offset = offset;
             switch (c) {
-            case '\"':
             case '\'':
-                if (pos >= len) {
+                // Single quotes can occur as digit separators in C++, this
+                // convention is inconsistent and nefarious to many respects
+                // and including it in the C Standard as of C2y is a shame.
+                if (style)
+                    break;
+                if (qe_isdigit(eb_peekc(s->b, this_offset))
+                &&  qe_isdigit(eb_peek_prevc(s->b, offset)))
+                    break;
+                FALLTHROUGH;
+            case '\"':
+                // we get here if scan started inside a string or a comment
+                // or if styles are disabled: try and skip the string backward
+                // using simplistic algorithm, ignoring escaped quotes
+                if (!style && pos > 0) {
                     /* simplistic string skip with escape char */
                     int off;
                     char32_t c1;
                     while ((c1 = eb_prevc(s->b, offset, &off)) != '\n') {
                         offset = off;
                         pos--;
-                        if (c1 == c && eb_prevc(s->b, offset, &off) != '\\')
+                        if (c1 == c && eb_peek_prevc(s->b, offset) != '\\')
                             break;
                     }
                 }
@@ -914,6 +961,7 @@ static void forward_block(EditState *s, int dir)
             case ']':
             case '}':
                 if (level < MAX_LEVEL) {
+                    delim_offset[level] = this_offset;
                     balance[level] = matching_delimiter(c);
                 }
                 level++;
@@ -925,6 +973,8 @@ static void forward_block(EditState *s, int dir)
                     --level;
                     if (level < MAX_LEVEL && balance[level] != c) {
                         /* XXX: should set mark and offset */
+                        s->b->mark = delim_offset[level];
+                        s->offset = offset;
                         put_error(s, "Unmatched delimiter %c <> %c",
                                   (int)c, (int)balance[level]);
                         goto done;
@@ -935,61 +985,79 @@ static void forward_block(EditState *s, int dir)
                     }
                 } else {
                     /* silently move up one level */
+                    // XXX: stop if argument?
                 }
                 break;
             }
         }
     } else {
         for (;;) {
+            int this_offset = offset;
             c = eb_nextc(s->b, offset, &offset);
             if (c == '\n') {
                 line_num++;
                 if (offset >= s->b->total_size)
                     break;
-                offset1 = offset0 = offset;
+                bol_offset = offset;
                 len = 0;
+                pos = 0;
                 if (use_colors) {
-                    len = get_colorized_line(cp, offset1, &offset1, line_num);
-                    if (len >= cp->buf_size - 2) {
+                    len = get_colorized_line(cp, bol_offset, &dummy_offset, line_num);
+                    if (cp->truncated) {
                         /* very long line detected, use fallback version */
                         use_colors = 0;
-                        len = 0;
                         style0 = 0;
                     }
                 }
-                pos = 0;
                 continue;
             }
-            style = 0;
-            if (pos < len) {
-                style = cp->sbuf[pos];
-            }
             pos++;
-            if (style0 != style && style != QE_STYLE_KEYWORD && style != QE_STYLE_FUNCTION) {
-                if (style0 == 0)
-                    continue;
-                style0 = 0;
-                if (style != 0)
-                    continue;
+            if (qe_isspace(c))
+                continue;
+            style = 0;
+            if (use_colors) {
+                if (pos <= len) {
+                    style = style_normalize(cp->sbuf[pos - 1]);
+                }
+                if (style0 != style) {
+                    if (style0 == 0) {
+                        // skip string or comment
+                        continue;
+                    }
+                    // stop at end of string or comment
+                    break;
+                }
             }
+            pending_offset = offset;
             switch (c) {
-            case '\"':
             case '\'':
-                if (pos >= len) {
+                // Single quotes can occur as digit separators in C++, this
+                // convention is inconsistent and nefarious to many respects
+                // and including it in the C Standard as of C2y is a shame.
+                if (style)
+                    break;
+                if (qe_isdigit(eb_peekc(s->b, offset))
+                &&  qe_isdigit(eb_peek_prevc(s->b, this_offset)))
+                    break;
+                FALLTHROUGH;
+            case '\"':
+                // We get here if scan started inside a string or a comment
+                // or if styles are disabled: try and skip the string using a
+                // simplistic algorithm, ignoring escaped quotes
+                if (!style && pos >= len) {
                     /* simplistic string skip with escape char */
                     int off;
                     char32_t c1;
                     while ((c1 = eb_nextc(s->b, offset, &off)) != '\n') {
                         offset = off;
                         pos++;
+                        if (c1 == c)
+                            break;
                         if (c1 == '\\') {
                             if (eb_nextc(s->b, offset, &off) == '\n')
                                 break;
                             offset = off;
                             pos++;
-                        } else
-                        if (c1 == c) {
-                            break;
                         }
                     }
                 }
@@ -998,6 +1066,7 @@ static void forward_block(EditState *s, int dir)
             case '[':
             case '{':
                 if (level < MAX_LEVEL) {
+                    delim_offset[level] = this_offset;
                     balance[level] = matching_delimiter(c);
                 }
                 level++;
@@ -1009,6 +1078,8 @@ static void forward_block(EditState *s, int dir)
                     --level;
                     if (level < MAX_LEVEL && balance[level] != c) {
                         /* XXX: should set mark and offset */
+                        s->b->mark = delim_offset[level];
+                        s->offset = offset;
                         put_error(s, "Unmatched delimiter %c <> %c",
                                   (int)c, (int)balance[level]);
                         goto done;
@@ -1019,6 +1090,7 @@ static void forward_block(EditState *s, int dir)
                     }
                 } else {
                     /* silently move up one level */
+                    // XXX: stop if argument?
                 }
                 break;
             }
@@ -1026,9 +1098,13 @@ static void forward_block(EditState *s, int dir)
     }
     if (level != 0) {
         /* XXX: should set mark and offset */
+        s->b->mark = delim_offset[level - 1];
+        s->offset = offset;
         put_error(s, "Unmatched delimiter");
     } else {
         s->offset = offset;
+        if (pending_offset >= 0)
+            s->offset = pending_offset;
     }
 done:
     cp_destroy(cp);
@@ -2188,10 +2264,9 @@ static int eb_sort_span(EditBuffer *b, int *pp1, int *pp2, int cur_offset, int f
         chunk_array[i].end = offset = eb_goto_eol(b, pos);
         offset = eb_next(b, offset);
         if (flags & SF_PARAGRAPH) {
-            int offset1;
             /* paragraph sorting: skip continuation lines */
             // XXX: Should ignore initial indent
-            while (offset < p2 && qe_isspace(eb_nextc(b, offset, &offset1))) {
+            while (offset < p2 && qe_isspace(eb_peekc(b, offset))) {
                 chunk_array[i].end = offset = eb_goto_eol(b, offset);
                 offset = eb_next(b, offset);
             }

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -353,8 +353,8 @@ in UTF-8. `offset` is bumped to point to the first unread character.
 * argument `offset` the offset in bytes of the beginning of the line in
 the buffer
 
-* argument `offset_ptr` a pointer to a variable to receive the offset
-of the first unread character in the buffer.
+* argument `offset_ptr` a nullable pointer to a variable to receive the
+offset of the first unread character in the buffer
 
 Return the number of bytes stored into the destination array before
 the newline if any. No partial encoding is stored into the array.
@@ -363,7 +363,7 @@ Note: the return value `len` verifies `len >= 0` and `len < buf_size`.
 If a complete line was read, `buf[len] == '\n'` and `buf[len + 1] == '\0'`.
 Truncation can be detected by checking `buf[len] != '\n'` or `len < buf_size - 1`.
 
-### `int eb_get_line(EditBuffer *b, char32_t *buf, int size, int offset, int *offset_ptr);`
+### `int eb_get_line(EditBuffer *b, char32_t *buf, int size, int offset, int *offset_ptr /* nullable */);`
 
 Get contents of the line starting at offset `offset` as an array of
 code points. `offset` is bumped to point to the first unread character.
@@ -377,17 +377,19 @@ code points. `offset` is bumped to point to the first unread character.
 * argument `offset` the offset in bytes of the beginning of the line in
 the buffer
 
-* argument `offset_ptr` a pointer to a variable to receive the offset
-of the first unread character in the buffer.
+* argument `offset_ptr` a nullable pointer to a variable to receive the
+offset of the first unread character in the buffer
 
 Return the number of codepoints stored into the destination array
 before the newline if any.
 
 Note: the return value `len` verifies `len >= 0` and `len < buf_size`.
 If a complete line was read, `buf[len] == '\n'` and `buf[len + 1] == '\0'`.
+A newline is stored at `buf[len]` even if at end of buffer without a trailing
+newline.
 Truncation can be detected by checking `buf[len] != '\n'` or `len < buf_size - 1`.
 
-### `int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr);`
+### `int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr /* nullable */);`
 
 Get the length in codepoints of the line starting at offset `offset`
 as an number of code points. `offset` is bumped to point to the first
@@ -398,8 +400,8 @@ character after the newline.
 * argument `offset` the offset in bytes of the beginning of the line in
 the buffer
 
-* argument `offset_ptr` a pointer to a variable to receive the offset
-of the first unread character in the buffer.
+* argument `offset_ptr` a nullable pointer to a variable to receive the
+offset of the first unread character in the buffer.
 
 Return the number of codepoints in the line including the newline if any.
 

--- a/qe.c
+++ b/qe.c
@@ -4681,42 +4681,6 @@ static int bidir_compute_attributes(BidirTypeLink *list_tab, int max_size,
 /* NOTE: only one colorization mode can be selected at a time for a
    buffer */
 
-static int get_staticly_colorized_line(QEColorizeContext *cp,
-                                       int offset, int *offset_ptr, int line_num)
-{
-    EditBuffer *b = cp->b;
-    int start_offset = offset, end_offset;
-    int len = 0;
-
-    for (;;) {
-        int next;
-        QETermStyle style = eb_get_style(b, offset);
-        char32_t c = eb_nextc(b, offset, &next);
-        if (len + 1 >= cp->buf_size) {
-            int new_size = min_int(eb_get_line_length(b, start_offset, &end_offset) + 1,
-                                   MAX_COLORED_LINE_SIZE);
-            if (cp->buf_size == new_size || !cp_reallocate(cp, new_size)) {
-                offset = end_offset;
-                cp->sbuf[len] = style;
-                cp->buf[len] = '\0';
-                break;
-            }
-        }
-        cp->sbuf[len] = style;
-        cp->buf[len++] = c;
-        offset = next;
-        if (c == '\n') {
-            /* end of line: offset points to the beginning of the next line */
-            /* adjust return value for easy stripping and truncation test */
-            cp->buf[len--] = '\0';
-            break;
-        }
-    }
-    if (offset_ptr)
-        *offset_ptr = offset;
-    return len;
-}
-
 void cp_colorize_line(QEColorizeContext *cp,
                       const char32_t *buf, int i, int n,
                       QETermStyle *sbuf, ModeDef *syn)
@@ -4780,7 +4744,40 @@ int cp_reallocate(QEColorizeContext *cp, int new_size) {
             return 0;
     }
     cp->buf_size = new_size;
+    cp->reallocated = 1;
     return 1;
+}
+
+// read a full line of codepoints from the context buffer, rellocate if needed
+// return the number of codepoints stored into `cp->buf`
+// `cp->truncated` is set iif line truncation occurs
+// `offset_ptr` is updated with the offset of the beginning of the next line
+int cp_get_line(QEColorizeContext *cp, int offset, int *offset_ptr) {
+    int len = eb_get_line(cp->b, cp->buf, cp->buf_size, offset, offset_ptr);
+    cp->truncated = 0;
+    if (cp->buf[len] != '\n') {
+        /* line was truncated */
+        int line_len = eb_get_line_length(cp->b, offset, offset_ptr);
+        int new_size = min_int(line_len + 2, MAX_COLORED_LINE_SIZE);
+        if (cp_reallocate(cp, new_size)) {
+            len = eb_get_line(cp->b, cp->buf, cp->buf_size, offset, NULL);
+        }
+        cp->truncated = len < line_len;
+    }
+    cp->buf[len] = '\0';
+    return len;
+}
+
+static int get_staticly_colorized_line(QEColorizeContext *cp,
+                                       int offset, int *offset_ptr)
+{
+    int len = cp_get_line(cp, offset, offset_ptr);
+    int i;
+    for (i = 0; i < len; i++) {
+        cp->sbuf[i] = eb_get_style(cp->b, offset);
+        offset = eb_next(cp->b, offset);
+    }
+    return len;
 }
 
 #ifndef CONFIG_TINY
@@ -4834,17 +4831,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
 
         for (line = s->colorize_nb_valid_lines; line <= line_num; line++) {
             cp->offset = offset;
-            len = eb_get_line(b, cp->buf, cp->buf_size, cp->offset, &offset);
-            if (cp->buf[len] != '\n') {
-                /* line was truncated */
-                int new_size = min_int(eb_get_line_length(b, cp->offset, &offset) + 1,
-                                       MAX_COLORED_LINE_SIZE);
-                if (cp_reallocate(cp, new_size)) {
-                    len = eb_get_line(s->b, cp->buf, cp->buf_size, cp->offset, NULL);
-                }
-            }
-            cp->buf[len] = '\0';
-
+            len = cp_get_line(cp, offset, &offset);
             /* skip byte order mark if present */
             bom = (cp->buf[0] == 0xFEFF);
             if (bom) {
@@ -4859,16 +4846,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
     cp->colorize_state = s->colorize_states[line_num];
     cp->state_only = 0;
     cp->offset = offset;
-    len = eb_get_line(b, cp->buf, cp->buf_size, offset, offsetp);
-    if (cp->buf[len] != '\n') {
-        /* line was truncated */
-        int new_size = min_int(eb_get_line_length(b, offset, offsetp) + 1,
-                               MAX_COLORED_LINE_SIZE);
-        if (cp_reallocate(cp, new_size)) {
-            len = eb_get_line(s->b, cp->buf, cp->buf_size, offset, NULL);
-        }
-    }
-    cp->buf[len] = '\0';
+    len = cp_get_line(cp, offset, offsetp);
     if (s->offset >= offset && s->offset < *offsetp + (s->offset == s->b->total_size)) {
         /* compute position of first codepoint before the cursor */
         int offset1 = offset;
@@ -4952,30 +4930,18 @@ void set_colorize_mode(EditState *s, ModeDef *colorize_mode)
 int get_colorized_line(QEColorizeContext *cp,
                        int offset, int *offsetp, int line_num)
 {
-    EditState *s = cp->s;
     int len;
 
 #ifndef CONFIG_TINY
-    if (s->colorize_mode) {
+    if (cp->s->colorize_mode) {
         len = syntax_get_colorized_line(cp, offset, offsetp, line_num);
     } else
 #endif
-    if (s->b->b_styles) {
-        len = get_staticly_colorized_line(cp, offset, offsetp, line_num);
+    if (cp->b->b_styles) {
+        len = get_staticly_colorized_line(cp, offset, offsetp);
     } else {
-        len = eb_get_line(s->b, cp->buf, cp->buf_size, offset, offsetp);
-        if (cp->buf[len] != '\n') {
-            /* line was truncated */
-            int new_size = min_int(eb_get_line_length(s->b, offset, offsetp) + 1,
-                                   MAX_COLORED_LINE_SIZE);
-            if (cp_reallocate(cp, new_size)) {
-                len = eb_get_line(s->b, cp->buf, cp->buf_size, offset, NULL);
-            }
-        }
-        cp->buf[len] = '\0';
-        if (cp->sbuf) {
-            memset(cp->sbuf, 0, (len + 1) * sizeof(*cp->sbuf));
-        }
+        len = cp_get_line(cp, offset, offsetp);
+        memset(cp->sbuf, 0, (len + 1) * sizeof(*cp->sbuf));
     }
     // XXX: should test if TABs should be colorized too
     // XXX: should colorize trailing blanks

--- a/qe.h
+++ b/qe.h
@@ -273,8 +273,10 @@ struct QEColorizeContext {
     EditBuffer *b;
     int offset;
     int colorize_state;
-    short state_only;
-    short partial_file;
+    u8 state_only;
+    u8 partial_file;
+    u8 reallocated;
+    u8 truncated;
     int combine_start, combine_stop; /* region for combine_static_colorized_line() */
     int cur_pos;   /* position of cursor in line or -1 if outside line */
     int buf_size;
@@ -285,8 +287,9 @@ struct QEColorizeContext {
 };
 
 QEColorizeContext *cp_initialize(QEColorizeContext *cp, EditState *s);
-int cp_reallocate(QEColorizeContext *cp, int new_size);
 void cp_destroy(QEColorizeContext *cp);
+int cp_reallocate(QEColorizeContext *cp, int new_size);
+int cp_get_line(QEColorizeContext *cp, int offset, int *offset_ptr);
 
 /* Colorize a line: this function modifies `sbuf` to set the character
  * styles. 'buf' is guaranted to have a '\0' at buf[n].
@@ -545,6 +548,9 @@ static inline int eb_prev(EditBuffer *b, int offset) {
 static inline int eb_peekc(EditBuffer *b, int offset) {
     return eb_nextc(b, offset, &offset);
 }
+static inline int eb_peek_prevc(EditBuffer *b, int offset) {
+    return eb_prevc(b, offset, &offset);
+}
 
 //int eb_clip_offset(EditBuffer *b, int offset);
 void do_repeat(EditState *s, int argval);
@@ -606,11 +612,9 @@ static inline int eb_get_contents(EditBuffer *b, char *buf, int buf_size, int en
 int eb_insert_buffer_convert(EditBuffer *dest, int dest_offset,
                              EditBuffer *src, int src_offset,
                              int size);
-int eb_get_line(EditBuffer *b, char32_t *buf, int size,
-                int offset, int *offset_ptr);
+int eb_get_line(EditBuffer *b, char32_t *buf, int size, int offset, int *offset_ptr);
 int eb_get_line_length(EditBuffer *b, int offset, int *offset_ptr);
-int eb_fgets(EditBuffer *b, char *buf, int size,
-             int offset, int *offset_ptr);
+int eb_fgets(EditBuffer *b, char *buf, int size, int offset, int *offset_ptr);
 int eb_prev_line(EditBuffer *b, int offset);
 int eb_goto_bol(EditBuffer *b, int offset);
 int eb_goto_bol2(EditBuffer *b, int offset, int *countp);


### PR DESCRIPTION
* improve block skipping:
  - if starting inside a string or a comment, skip to the end of the string or comment while balancing blocks
  - otherwise skip string and comments when balancing blocks
  - fix behavior on very long lines, eg: **highlight.pack.js**
* if a nesting error occurs, point and mark are set around the mismatched delimiters. use C-x C-x to skip between them
* simplify `get_colorized_line()`
* add `cp_get_line()` to factorize code
* add `eb_peek_prevc()` to get previous codepoint without end offset
* improve documentation conciseness