### PR TITLE
Improve popups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-<!-- TODO list for qemacs -- Author: Charlie Gordon -- Updated: 2025-02-10 -->
+<!-- TODO list for qemacs -- Author: Charlie Gordon -- Updated: 2026-05-15 -->
 
 # QEmacs TODO list
 
@@ -6,7 +6,6 @@
 
 * encode non printing characters in filenames and buffer names
 * change buffer list layout to increase buffer name width if needed
-* support M-n and M-p to move by 4 lines in popup lists
 * fix warning: `int (*eb_printf_fun)(EditBuffer *b, const char *fmt, ...) = (void*)eb_printf;`
 * fix crash bug on `C-X C-B C-X C-F xxx RET`
 * fix cursor positioning beyond end of screen

--- a/qe.c
+++ b/qe.c
@@ -8107,12 +8107,18 @@ static const CmdDef minibuffer_commands[] = {
           "Try and complete the minibuffer input",
           do_minibuffer_complete_space, ESii,
           "*" "k" "p")
-    CMD2( "minibuffer-previous-history-element", "C-p, up, M-p",
+    CMD2( "minibuffer-previous-history-element", "C-p, up",
           "Replace contents of the minibuffer with the previous historical entry",
           do_minibuffer_history, ESi, "q")
-    CMD2( "minibuffer-next-history-element", "C-n, down, M-n",
+    CMD2( "minibuffer-next-history-element", "C-n, down",
           "Replace contents of the minibuffer with the next historical entry",
           do_minibuffer_history, ESi, "p")
+    CMD1( "minibuffer-next-fourth-history-element", "M-n",
+          "Replace contents of the minibuffer with the fourth next historical entry",
+          do_minibuffer_history, 4)
+    CMD1( "minibuffer-previous-fourth-history-element", "M-p",
+          "Replace contents of the minibuffer with the fourth previous historical entry",
+          do_minibuffer_history, -4)
     CMD2( "minibuffer-electric-key", "/, ~",
           "Insert a character into the minibuffer with side effects",
           do_minibuffer_electric_key, ESii,

--- a/qe.c
+++ b/qe.c
@@ -8273,9 +8273,17 @@ EditState *show_popup(EditState *s, EditBuffer *b, const char *caption)
     EditState *e;
     int w, h, w1, h1;
 
-    /* Prevent recursion */
-    if (s && s->b == b)
+    b->flags |= BF_READONLY;
+
+    /* Update caption and prevent recursion */
+    if (s && s->b == b) {
+        if (s->caption)
+            qe_free(&s->caption);
+        if (caption)
+            s->caption = qe_strdup(caption);
+        do_refresh(s);
         return s;
+    }
 
     /* XXX: generic function to open popup ? */
     w1 = qs->screen->width;
@@ -8284,7 +8292,6 @@ EditState *show_popup(EditState *s, EditBuffer *b, const char *caption)
     h = (h1 * 3) / 4;
 
     b->default_mode = &popup_mode;
-    b->flags |= BF_READONLY;
     e = qe_new_window(b, (w1 - w) / 2, (h1 - h) / 2, w, h, WF_POPUP);
     if (e != NULL) {
         if (caption)
@@ -8303,6 +8310,9 @@ static const CmdDef popup_commands[] = {
     CMD3( "popup-isearch", "/",
           "Search for contents",
           do_isearch, ESii, "p" "v", 1)
+    CMD1( "popup-abort", "q, C-x 0, CLOSE",
+          "Quit popup window",
+          do_delete_window, 1)
 };
 
 static void popup_init(QEmacsState *qs)
@@ -9646,6 +9656,8 @@ void do_other_window(EditState *s)
 {
     EditState *e = get_next_window(s, 0, 0);
     if (e) {
+        if (e->flags & WF_POPUP)
+            return;
         if (e->flags & WF_MINIBUF)
             edit_invalidate(e, 0);
         s->qs->active_window = e;
@@ -10108,7 +10120,6 @@ void do_help_for_help(EditState *s)
     if (!b)
         return;
 
-    // FIXME: use minor mode for `q` to quit
     eb_puts(b,
             "QEmacs help for help - Press q to quit:\n"
             "\n"


### PR DESCRIPTION
- support `M-n` and `M-p` to move by 4 lines.
- Add `popup-abort` command.
- Update caption and restore readonly when reusing popup buffer.
- Prevent bugs when changing from minibuf to popup window.