### PR TITLE
Shell mode improvements

### DIFF
--- a/modes/shell.c
+++ b/modes/shell.c
@@ -111,9 +111,9 @@ typedef struct ShellError {
 typedef struct ShellKillContext {
     ShellState *s;
     EditBuffer *b;
+    void (*callback)(EditState*, const char*);
     EditState *e;
     const char *cmd;
-    void (*callback)(EditState*, const char*);
 } ShellKillContext;
 
 static ShellError error_state = {
@@ -3514,8 +3514,8 @@ static void do_shell_command(EditState *e, const char *cmd)
 {
     char curpath[MAX_FILENAME_SIZE];
     QEmacsState *qs = e->qs;
-    EditBuffer *b;
     const char *bufname = "*shell command output*";
+    EditBuffer *b;
 
     get_default_path(e->b, e->offset, curpath, sizeof curpath);
 
@@ -3543,7 +3543,7 @@ static void do_interactive_shell_command(EditState *e, const char *cmd)
     get_default_path(e->b, e->offset, curpath, sizeof curpath);
 
     /* create new buffer */
-    b = qe_new_shell_buffer(qs, NULL, e, "*interactive shell command*", NULL,
+    b = qe_new_shell_buffer(qs, NULL, e, "*interactive shell command*", "Shell process",
                             curpath, cmd, SF_COLOR | SF_INFINITE | SF_INTERACTIVE);
     if (!b)
         return;
@@ -3559,8 +3559,8 @@ static void do_compile(EditState *s, const char *cmd)
 {
     char curpath[MAX_FILENAME_SIZE];
     QEmacsState *qs = s->qs;
-    EditBuffer *b;
     const char *bufname = "*compilation*";
+    EditBuffer *b;
 
     if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2796,7 +2796,7 @@ static void do_shell(EditState *e, int argval)
 
 static inline EditState *shell_target_window(EditState *e, EditBuffer *b)
 {
-    EditState *e1, *e2;
+    EditState *e1 = NULL, *e2;
     QEmacsState *qs = e->qs;
     ShellState *s = qe_get_buffer_mode_data(b, &shell_mode, NULL);
 
@@ -2808,10 +2808,10 @@ static inline EditState *shell_target_window(EditState *e, EditBuffer *b)
 
     int size1, size = 0;
     for (e2 = qs->first_window; e2 != NULL; e2 = e2->next_window) {
-        if (e2 == qs->active_window)
+        if (e2 == qs->active_window || e2->flags & (WF_MINIBUF | WF_POPUP))
             continue;
 
-        size1 = (e2->x2 - e2->x1) * (e2->y2 - e2->y1);
+        size1 = e2->width * e2->height;
         if (size1 > size) {
             size = size1;
             e1 = e2;
@@ -2820,8 +2820,12 @@ static inline EditState *shell_target_window(EditState *e, EditBuffer *b)
 
     if (e1 == NULL) {
         e1 = qe_split_window(e, SW_STACKED, 50);
-        if (e1 ==  NULL)
+        if (e1 == NULL) {
             e1 = e;
+        } else {
+            switch_to_buffer(e1, NULL);
+            e1->last_buffer = NULL;
+        }
     }
 
 found:
@@ -4100,6 +4104,30 @@ static int pager_mode_init(EditState *e, EditBuffer *b, int flags)
     return 0;
 }
 
+static void do_pager_abort(EditState *e)
+{
+    EditBuffer *b1;
+
+    if (e->mode != &pager_mode) {
+        put_error(e, "Not a %s buffer", pager_mode.name);
+    } else {
+        b1 = qe_check_buffer(e->qs, &e->last_buffer);
+        if (b1 != NULL) {
+            switch_to_buffer(e, NULL);
+            e->last_buffer = NULL;
+            switch_to_buffer(e, b1);
+        } else { 
+            do_delete_window(e, 0);
+        }
+    }
+}
+
+static const CmdDef pager_commands[] = {
+    CMD0( "pager-abort", "q",
+          "Quit pager mode",
+          do_pager_abort)
+};
+
 /* additional mode specific bindings */
 static const char * const pager_bindings[] = {
     "DEL", "scroll-down",
@@ -4146,6 +4174,7 @@ static int shell_init(QEmacsState *qs)
     pager_mode.bindings = pager_bindings;
 
     qe_register_mode(qs, &pager_mode, MODEF_NOCMD | MODEF_VIEW);
+    qe_register_commands(qs, &pager_mode, pager_commands, countof(pager_commands));
 
     return 0;
 }

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2462,6 +2462,11 @@ static void shell_read_cb(void *opaque)
         b->flags |= BF_READONLY;
     }
 
+    EditState *e = qs->active_window;
+    if (e->b == b && e->interactive == 0
+        && qs->last_cmd_func == (CmdFunc)do_eof)
+        e->offset = b->total_size;
+
     /* now we do some refresh (should just invalidate?) */
     qe_display(qs);
 }
@@ -2552,28 +2557,37 @@ static void shell_close(ShellState *s)
 
         ti = time(NULL);
         time_str = ctime(&ti);
-        if (WIFEXITED(status))
-            status = WEXITSTATUS(status);
-        else
-            status = -1;
-        if (status == 0) {
-            snprintf(buf, sizeof(buf), "\n%s finished at %s",
-                     s->caption, time_str);
-        } else {
-            snprintf(buf, sizeof(buf), "\n%s exited abnormally with code %d at %s",
-                     s->caption, status, time_str);
+        if (WIFEXITED(status)) {
+            int code = WEXITSTATUS(status);
+            if (code == 0)
+                snprintf(buf, sizeof(buf), "%s finished", s->caption);
+            else
+                snprintf(buf, sizeof(buf), "%s exited abnormally with code %d",
+                         s->caption, code);
+        } else if (WIFSIGNALED(status)) {
+            snprintf(buf, sizeof(buf), "%s %s",
+                     s->caption, strsignal(WTERMSIG(status)));
         }
-    }
-    {
-        /* Flush output to buffer, bypassing readonly flag */
-        int save_readonly = s->b->flags & BF_READONLY;
-        s->b->flags &= ~BF_READONLY;
+        if (*buf != '\0') {
+            if (!(s->shell_flags & SF_INTERACTIVE))
+                put_status(qs->active_window, "%s", buf);
 
-        eb_write(b, b->total_size, buf, strlen(buf));
+            /* Flush output to buffer, bypassing readonly flag */
+            int save_readonly = s->b->flags & BF_READONLY;
+            s->b->flags &= ~BF_READONLY;
 
-        if (save_readonly) {
-            s->b->modified = 0;
-            s->b->flags |= BF_READONLY;
+            b->offset = b->total_size;
+            eb_printf(b, "\n%s at %s", buf, time_str);
+
+            e = qs->active_window;
+            if (e->b == b && e->interactive == 0
+                && qs->last_cmd_func == (CmdFunc)do_eof)
+                e->offset = b->total_size;
+
+            if (save_readonly) {
+                s->b->modified = 0;
+                s->b->flags |= BF_READONLY;
+            }
         }
     }
 

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2796,7 +2796,8 @@ static void do_shell(EditState *e, int argval)
 
 static inline EditState *shell_target_window(EditState *e, EditBuffer *b)
 {
-    EditState *e1;
+    EditState *e1, *e2;
+    QEmacsState *qs = e->qs;
     ShellState *s = qe_get_buffer_mode_data(b, &shell_mode, NULL);
 
     if (s && !(s->shell_flags & SF_INTERACTIVE)) {
@@ -2805,9 +2806,23 @@ static inline EditState *shell_target_window(EditState *e, EditBuffer *b)
             goto found;
     }
 
-    e1 = qe_split_window(e, SW_STACKED, 50);
-    if (e1 ==  NULL)
-        e1 = e;
+    int size1, size = 0;
+    for (e2 = qs->first_window; e2 != NULL; e2 = e2->next_window) {
+        if (e2 == qs->active_window)
+            continue;
+
+        size1 = (e2->x2 - e2->x1) * (e2->y2 - e2->y1);
+        if (size1 > size) {
+            size = size1;
+            e1 = e2;
+        }
+    }
+
+    if (e1 == NULL) {
+        e1 = qe_split_window(e, SW_STACKED, 50);
+        if (e1 ==  NULL)
+            e1 = e;
+    }
 
 found:
     switch_to_buffer(e1, b);


### PR DESCRIPTION
- Cosmetic changes:
  - add interactive shell process caption.
  - rearrange lines.

- Pager add `pager-abort` command.

- Refine target window selection logic:

  The behavior follows this priority order:

  1. Reuse an existing window already displaying the buffer.
  2. Select the largest available non-active window.
  3. Split a new window if no sutiable window is found.
  4. Fall back to the current window if splitting fails.

- Improve shell_close/shell_read_cb:
  - add check when process is signaled.
  - put appropriate status message when non-interactive.
  - follow output stream when non-interactive.