### PR TITLE
fix issues introduced by recent pager changes

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -543,8 +543,8 @@ int eb_delete(EditBuffer *b, int offset, int size)
 
 /*---------------- finding buffers ----------------*/
 
-/* Verify that window still exists, return argument or NULL,
- * update handle if window is invalid.
+/* Verify that buffer still exists, return argument or NULL,
+ * update handle if buffer is invalid.
  */
 EditBuffer *qe_check_buffer(QEmacsState *qs, EditBuffer **sp)
 {

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2829,7 +2829,7 @@ static EditState *shell_target_window(EditState *e, EditBuffer *b)
             if (e2->flags & (WF_POPUP | WF_MINIBUF | WF_POPLEFT))
                 continue;
             if (e2 != qs->active_window) {
-                int size2 = (e2->x2 - e2->x1) * (e2->y2 - e2->y1);
+                int size2 = e2->width * e2->height;
                 if (size2 > size1) {
                     size1 = size2;
                     e1 = e2;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2842,9 +2842,8 @@ static EditState *shell_target_window(EditState *e, EditBuffer *b)
             if (e1 == NULL) {
                 e1 = e;
             } else {
-                switch_to_buffer(e1, b);
+                switch_to_buffer(e1, NULL);
                 e1->last_buffer = NULL;
-                return e1;
             }
         }
     }
@@ -4124,18 +4123,28 @@ static int pager_mode_init(EditState *e, EditBuffer *b, int flags)
     return 0;
 }
 
-static void do_pager_abort(EditState *e, int force)
+static void do_pager_abort(EditState *e)
 {
-    if (force || e->last_buffer == NULL)
-        do_delete_window(e, 0);
-    else
-        switch_to_buffer(e, e->last_buffer);
+    EditBuffer *b1;
+
+    if (e->mode != &pager_mode) {
+        put_error(e, "Not a %s buffer", pager_mode.name);
+    } else {
+        b1 = qe_check_buffer(e->qs, &e->last_buffer);
+        if (b1 != NULL) {
+            switch_to_buffer(e, NULL);
+            e->last_buffer = NULL;
+            switch_to_buffer(e, b1);
+        } else {
+            do_delete_window(e, 0);
+        }
+    }
 }
 
 static const CmdDef pager_commands[] = {
-    CMD1( "pager-abort", "q",
+    CMD0( "pager-abort", "q",
           "Quit pager mode",
-          do_pager_abort, 0)
+          do_pager_abort)
 };
 
 /* additional mode specific bindings */


### PR DESCRIPTION
- `pager-abort` did not check mode, and did not check if buffer was killed so I fixed that.
- `shell_target_widnow` now utlizes stored window width and height instead of recomputing them.