### PR TITLE
util: do not test pointer before calling `qe_free`

### DIFF
--- a/qe.c
+++ b/qe.c
@@ -8278,8 +8278,7 @@ EditState *show_popup(EditState *s, EditBuffer *b, const char *caption)
     if (s && (s->flags & WF_POPUP)) {
         if (s->b != b)
             switch_to_buffer(s, b);
-        if (s->caption)
-            qe_free(&s->caption);
+        qe_free(&s->caption);
         if (caption)
             s->caption = qe_strdup(caption);
         do_refresh(s);

--- a/util.c
+++ b/util.c
@@ -2027,8 +2027,7 @@ StringItem *set_string(StringArray *cs, int index, const char *str, int group)
     v->selected = 0;
     v->group = group;
     memcpy(v->str, str, len + 1);
-    if (cs->items[index])
-        qe_free(&cs->items[index]);
+    qe_free(&cs->items[index]);
     cs->items[index] = v;
     return v;
 }


### PR DESCRIPTION
* testing the pointer before calling `qe_free` is considered useless and bad style in the project.