### PR TITLE
Sundries: bug fixes

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -44,9 +44,9 @@ Equivalent *create_equivalent(const char *str1, const char *str2) {
 }
 
 void delete_equivalent(Equivalent *ep) {
-    qe_free(ep->str1);
-    qe_free(ep->str2);
-    qe_free(ep);
+    qe_free(&ep->str1);
+    qe_free(&ep->str2);
+    qe_free(&ep);
 }
 
 static void do_define_equivalent(EditState *s, const char *str1, const char *str2)

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -76,7 +76,6 @@ typedef struct ShellState {
     int params[MAX_CSI_PARAMS + 1];
     int state;
     int esc1, esc2;
-    int this_byte, last_byte;
     char32_t lastc;
     int shifted;
     int cset, charset[2];
@@ -114,7 +113,7 @@ typedef struct ShellKillContext {
     EditBuffer *b;
     void (*callback)(EditState*, const char*);
     EditState *e;
-    const char *cmd;
+    char *cmd;  /* allocated */
 } ShellKillContext;
 
 static ShellError error_state = {

--- a/qe.c
+++ b/qe.c
@@ -12098,7 +12098,7 @@ int main(int argc, char **argv)
             if (vp->str_alloc)
                 qe_free(&vp->value.str);
             if (vp->var_alloc) {
-                qe_free(&vp->name);
+                qe_free(unconst(char **)&vp->name);
                 qe_free(&vp);
             }
         }

--- a/qe.h
+++ b/qe.h
@@ -1185,7 +1185,7 @@ typedef enum CmdSig {
 typedef union CmdArg {
     EditState *s;
     void *vp;
-    const char *p;
+    char *p; /* allocated */
     int n;
 } CmdArg;
 

--- a/tty.c
+++ b/tty.c
@@ -289,8 +289,8 @@ static int tty_dpy_init(QEditScreen *s, QEmacsState *qs,
                         qe__unused__ int w, qe__unused__ int h)
 {
     TTYState *ts;
-    struct termios tty;
-    struct sigaction sig;
+    struct termios tty = { 0 };
+    struct sigaction sig = { 0 };
     const char *p;
 
     ts = qe_mallocz(TTYState);


### PR DESCRIPTION
* fix crash bug on `delete_equivalent()`: qe_free takes a double pointer
* remove unused ShellState variables
* initialize term structures