### PR TITLE
bufed/dired: toggle hex display for non-ASCII codepoints

### DIFF
--- a/modes/bufed.c
+++ b/modes/bufed.c
@@ -656,7 +656,7 @@ int buffer_print_entry(CompleteState *cp, EditState *s, const char *name)
     if (b1) {
         b->cur_style = QE_STYLE_KEYWORD;
         len = eb_put_filename(b, b1->name, bufed_pf_flags);
-        b->tab_width = max3_int(16, len + 2, b->tab_width);
+        b->tab_width = max3_int(16, len + 3, b->tab_width);
         len += eb_putc(b, '\t');
         if (*b1->filename) {
             b->cur_style = QE_STYLE_COMMENT;

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -370,9 +370,17 @@ int eb_put_filename(EditBuffer *b, const char *name, int flags) {
                 int nc = utf8_encode(buf, c);
                 if (nc == p - name + 1 && !memcmp(buf, name - 1, nc)) {
                     // valid UTF-8 encoded codepoint
-                    buf[nc] = '\0';
-                    eb_puts(b, buf);
-                    len += qe_wcwidth(c);
+                    if (flags & 1) {
+                        if (c > 0xFFFF) {
+                            len += eb_printf(b, "\\u{%X}", c);
+                        } else {
+                            len += eb_printf(b, "\\x%04X", c);
+                        }
+                    } else {
+                        buf[nc] = '\0';
+                        eb_puts(b, buf);
+                        len += qe_wcwidth(c);
+                    }
                     name = p;
                     continue;
                 }
@@ -385,8 +393,16 @@ int eb_put_filename(EditBuffer *b, const char *name, int flags) {
                 len += 1;
                 break;
             case PF_OCTAL:
-                eb_printf(b, "\\%03o", cc);
-                len += 4;
+                eb_putc(b, '\\');
+                len += 2;
+                switch (cc) {
+                case '\n':  eb_putc(b, 'n'); break;
+                case '\t':  eb_putc(b, 't'); break;
+                case '\r':  eb_putc(b, 'r'); break;
+                case '\b':  eb_putc(b, 'b'); break;
+                case '\f':  eb_putc(b, 'f'); break;
+                default:    eb_printf(b, "%03o", cc); len += 2; break;
+                }
                 break;
             case PF_HEX:
                 eb_printf(b, "\\x%02X", cc);

--- a/qe.h
+++ b/qe.h
@@ -1902,8 +1902,8 @@ int list_get_offset(EditState *s);
 
 #define PF_QUESTION    0
 #define PF_CARET       1
-#define PF_HEX         2
-#define PF_OCTAL       3
+#define PF_OCTAL       2
+#define PF_HEX         3
 #define PF_ENCODING    3
 #define PF_NO_UNICODE  8
 int eb_put_filename(EditBuffer *b, const char *name, int flags);


### PR DESCRIPTION
* `dired-toggle-encoding` and `bufed-toggle-encoding` (key \) also toggle display of Unicode letters as hex escapes