### PR TITLE
Configure: reorganize the configure script and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # QEmacs, tiny but powerful multimode editor
 #
 # Copyright (c) 2000-2002 Fabrice Bellard.
-# Copyright (c) 2000-2025 Charlie Gordon.
+# Copyright (c) 2000-2026 Charlie Gordon.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,10 @@
 
 DEPTH=.
 OSNAME:=$(shell uname -s)
+
+ifeq (,$(wildcard $(DEPTH)/config.mak))
+    $(error you should run ./configure prior to make)
+endif
 
 include $(DEPTH)/config.mak
 
@@ -116,17 +120,51 @@ CFLAGS += -D__UBSAN__
 CFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS) -g
 LDFLAGS += -fsanitize=undefined $(SANITIZE_CFLAGS) -g
 endif
+ifdef CONFIG_32BIT
+CFLAGS += -m32
+LDFLAGS += -m32
+endif
+
+BINDIR:=$(DEPTH)/bin
 
 TARGETLIBS:=
 
-TOP:=0
 ifeq (,$(TARGET))
-TARGET:=qe
-TARGETS:=kmaps ligatures tqe qe-manual.md
-ifeq (,$(DEBUG_SUFFIX))
-TOP:=1
+
+TARGETS :=
+ifndef CONFIG_TINY_ONLY
+  TARGETS += qe
 endif
+ifdef CONFIG_TINY
+  TARGETS += tqe
 endif
+ifdef CONFIG_X11
+  TARGETS += xqe
+endif
+ifdef CONFIG_DOC
+  TARGETS += qe-doc.html
+endif
+TARGET_OBJ := other
+
+all: $(TARGETS)
+
+# targets that require recursion
+qe:		force;	$(MAKE) TARGET=qe
+xqe:		force;	$(MAKE) TARGET=xqe TARGET_OBJ=qe TARGET_X11=1
+tqe:		force;	$(MAKE) TARGET=tqe TARGET_TINY=1
+tqe1:		force;	$(MAKE) TARGET=tqe TARGET_TINY=1 tqe1$(EXE)
+asan qe_asan:	force;	$(MAKE) TARGET=qe ASAN=1
+msan qe_msan:	force;	$(MAKE) TARGET=qe MSAN=1
+ubsan qe_ubsan:	force;	$(MAKE) TARGET=qe UBSAN=1
+debug qe_debug:	force;	$(MAKE) TARGET=qe DEBUG=1
+xqe_debug:	force;	$(MAKE) TARGET=xqe TARGET_OBJ=qe TARGET_X11=1 DEBUG=1
+tqe_debug:	force;	$(MAKE) TARGET=tqe TARGET_TINY=1 DEBUG=1
+qe-manual.md:   force;  $(MAKE) TARGET=qe qe-manual.md
+
+else
+
+# We have a specific TARGET (qe, xqe or tqe)
+
 ifeq (,$(TARGET_OBJ))
 TARGET_OBJ:=$(TARGET)
 endif
@@ -134,18 +172,11 @@ endif
 OBJS:= qe.o cutils.o util.o color.o charset.o buffer.o search.o input.o display.o \
        qescript.o modes/hex.o
 
-ifdef CONFIG_32BIT
-CFLAGS += -m32
-LDFLAGS += -m32
-endif
-
 ifdef TARGET_TINY
 ECHO_CFLAGS += -DCONFIG_TINY
 CFLAGS += -DCONFIG_TINY -Os
 #CFLAGS += -m32
 #LDFLAGS += -m32
-else
-OBJS+= extras.o variables.o
 endif
 
 #ifdef CONFIG_DARWIN
@@ -162,10 +193,6 @@ ifdef CONFIG_DLL
   LDFLAGS += -Wl,-E
 endif
 
-ifdef CONFIG_DOC
-  TARGETS += qe-doc.html
-endif
-
 ifdef CONFIG_HAIKU
   OBJS += haiku.o
   LIBS += -lbe -lstdc++
@@ -180,7 +207,14 @@ else
   LIBS+= $(EXTRALIBS)
 endif
 
+ifeq (qe,$(TARGET))
+# qe-manual.md depends on $(SRCS) and $(DEPENDS)
+TARGETS += kmaps ligatures qe-manual.md
+endif
+
 ifndef TARGET_TINY
+
+OBJS+= extras.o variables.o
 
 ifdef CONFIG_QSCRIPT
   OBJS+= qscript.o eval.o
@@ -218,7 +252,7 @@ OBJS+= modes/unihex.o   modes/bufed.o    modes/orgmode.o  modes/markdown.o \
 ifndef CONFIG_WIN32
 OBJS+= modes/shell.o    modes/dired.o    modes/archive.o  modes/latex-mode.o
 endif
-endif
+endif  # ifdef CONFIG_ALL_MODES
 
 # currently not used in qemacs
 ifdef CONFIG_CFB
@@ -249,14 +283,10 @@ else
   OBJS+= modes/stb.o
 endif
 
-ifdef CONFIG_X11
-  TARGETS += xqe
-endif
-
 ifdef TARGET_X11
   OBJS+= x11.o
-  ECHO_CFLAGS += -DCONFIG_X11
-  DEFINES += -DCONFIG_X11
+  #ECHO_CFLAGS += -DCONFIG_X11
+  #DEFINES += -DCONFIG_X11
   CFLAGS += $(XCFLAGS)
   LDFLAGS += $(XLDFLAGS)
   LIBS += $(XLIBS)
@@ -281,24 +311,12 @@ DEPENDS:= qe.h config.h config.mak charset.h color.h cutils.h display.h \
 
 DEPENDS:= $(addprefix $(DEPTH)/, $(DEPENDS))
 
-BINDIR:=$(DEPTH)/bin
-
 OBJS_DIR:= $(DEPTH)/.objs/$(TARGET_OS)-$(TARGET_ARCH)-$(CC)/$(TARGET_OBJ)$(DEBUG_SUFFIX)
 CFLAGS+= -I$(OBJS_DIR)
 OBJS:= $(addprefix $(OBJS_DIR)/, $(OBJS))
 OBJS+= $(OBJS_DIR)/$(TARGET)_modules.o
 
-#
-# Dependencies
-#
-ifeq (1,$(TOP))
 all: $(TARGETLIBS) $(TARGET)$(DEBUG_SUFFIX)$(EXE) $(TARGETS)
-else
-all: $(TARGETLIBS) $(TARGET)$(DEBUG_SUFFIX)$(EXE)
-endif
-
-libqhtml: force
-	$(MAKE) -C libqhtml all
 
 ifneq (,$(DEBUG_SUFFIX))
 $(TARGET)$(DEBUG_SUFFIX)$(EXE): $(OBJS) $(DEP_LIBS)
@@ -318,22 +336,8 @@ $(TARGET)$(EXE): $(TARGET)_g$(EXE) Makefile
 		| cut -d ' ' -f 7-10,13,15-40 >> STATS
 endif
 
-ifeq (1,$(TOP))
-
-# targets that require recursion
-xqe:		force;	$(MAKE) TARGET=xqe TARGET_OBJ=qe TARGET_X11=1
-tqe:		force;	$(MAKE) TARGET=tqe TARGET_TINY=1
-tqe1:		force;	$(MAKE) TARGET=tqe TARGET_TINY=1 tqe1$(EXE)
-asan qe_asan:	force;	$(MAKE) TARGET=qe ASAN=1
-msan qe_msan:	force;	$(MAKE) TARGET=qe MSAN=1
-ubsan qe_ubsan:	force;	$(MAKE) TARGET=qe UBSAN=1
-debug qe_debug:	force;	$(MAKE) TARGET=qe DEBUG=1
-xqe_debug:	force;	$(MAKE) TARGET=xqe TARGET_OBJ=qe TARGET_X11=1 DEBUG=1
-tqe_debug:	force;	$(MAKE) TARGET=tqe TARGET_TINY=1 DEBUG=1
-
-else
-
-# Amalgation mode produces a larger executable
+ifeq (tqe,$(TARGET))
+# Amalgamation mode produces a larger executable
 TSRCS:=qe.c cutils.c util.c color.c charset.c buffer.c search.c input.c display.c \
        modes/hex.c parser.c unix.c tty.c win32.c qeend.c
 TSRCS+= $(OBJS_DIR)/tqe_modules.c
@@ -408,6 +412,11 @@ $(OBJS_DIR)/haiku.o: haiku.cpp $(DEPENDS) Makefile
 
 %.s: %.cpp $(DEPENDS) Makefile
 	g++ $(DEFINES) $(CFLAGS) -Wno-multichar -o $@ -S $<
+
+endif # ifneq(,$(TARGET))
+
+libqhtml: force
+	$(MAKE) -C libqhtml all
 
 #
 # Host utilities
@@ -527,6 +536,7 @@ unicode_width: $(BINDIR)/unitable$(EXE) Makefile
 #libunicode_table: $(BINDIR)/unicode_gen$(EXE) Makefile
 #	$(BINDIR)/unicode_gen libunicode-table.h
 
+ifneq (,$(TARGET))
 #
 # fonts (only needed for html2png)
 #
@@ -557,14 +567,13 @@ OBJS1:=$(addprefix $(OBJS_DIR)/, $(OBJS1))
 html2png$(EXE): $(OBJS1) $(LIBQHTML)
 	$(echo) LD $@
 	$(cmd)  $(CC) $(LDFLAGS) -o $@ $(OBJS1) $(QHTML_LIBS) $(HTMLTOPPM_LIBS)
+endif
 
-# autotest target
-test:
-	$(MAKE) -C tests test
-
+ifeq (qe,$(TARGET))
 # documentation
 qe-manual.md: $(BINDIR)/scandoc$(EXE) qe-manual.c $(SRCS) $(DEPENDS) Makefile
 	$(BINDIR)/scandoc$(EXE) qe-manual.c $(SRCS) $(DEPENDS) > $@
+endif
 
 qe-doc.html: qe-doc.texi Makefile
 	LANGUAGE=en_US LC_ALL=en_US.UTF-8 texi2html -monolithic $<
@@ -589,7 +598,7 @@ clean:
 	rm -f *~ *.o *.a *.exe *_g *_debug TAGS gmon.out core *.exe.stackdump \
            qe tqe tqe1 xqe kmaptoqe ligtoqe html2png cptoqe jistoqe \
            fbftoqe fbffonts.c allmodules.txt basemodules.txt '.#'*[0-9] \
-           qe_asan qe_msan qe_ubsan
+           *qe_asan *qe_msan *qe_ubsan
 
 distclean: clean
 	$(MAKE) -C libqhtml distclean
@@ -602,7 +611,7 @@ install: $(TARGETS) qe.1
 ifdef CONFIG_X11
 	$(INSTALL) -m 755 -s xqe$(EXE) $(DESTDIR)$(prefix)/bin/qemacs$(EXE)
 else
-  ifdef CONFIG_TINY
+  ifdef CONFIG_TINY_ONLY
 	$(INSTALL) -m 755 -s tqe$(EXE) $(DESTDIR)$(prefix)/bin/qemacs$(EXE)
   else
 	$(INSTALL) -m 755 -s qe$(EXE) $(DESTDIR)$(prefix)/bin/qemacs$(EXE)
@@ -634,6 +643,10 @@ rebuild:
 
 TAGS: force
 	etags *.[ch]
+
+# autotest target
+test:
+	$(MAKE) -C tests test
 
 colortest:
 	tests/16colors.pl

--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 # QEmacs configure script
 #
 # Copyright (c) 2002 Fabrice Bellard
-# Copyright (c) 2002-2023 Charlie Gordon
+# Copyright (c) 2002-2026 Charlie Gordon
 #
 #
 # set temporary file name
@@ -71,7 +71,8 @@ extralibs=""
 simpleidct="yes"
 bigendian="no"
 
-tiny="no"
+tiny_only="no"
+tiny="yes"
 x11="no"
 xv="no"
 xshm="no"
@@ -231,11 +232,12 @@ echo "  --disable-x11            disable Xwindow support"
 echo "  --disable-xv             disable Xvideo extension support"
 echo "  --disable-xshm           disable XShm extension support"
 echo "  --disable-xrender        disable Xrender extension support"
-echo "  --enable-tiny            build a very small version"
+echo "  --disable-tiny           do not build the very small version"
 echo "  --disable-html           disable graphical html support"
 echo "  --disable-png            disable png support"
 echo "  --disable-plugins        disable plugins support"
 echo "  --disable-ffmpeg         disable ffmpeg support"
+echo "  --tiny-only              only build the very small version"
 echo "  --with-ffmpegdir=DIR     find ffmpeg sources and libraries in DIR"
 echo "                           for audio/video/image support"
 echo ""
@@ -295,6 +297,9 @@ for opt do
         ;;
       --with-ffmpeglibdir=*)
         ffmpeg_libdir=${opt#--with-ffmpeglibdir=}
+        ;;
+      --tiny-only)
+        tiny_only="yes"
         ;;
       --disable-*)
         value="no"
@@ -491,7 +496,8 @@ if test "$ffmpeg" = "yes" ; then
     fi
 fi
 
-if test "$tiny" = "yes" ; then
+if test "$tiny_only" = "yes" ; then
+    tiny="yes"
     ffmpeg="no"
     x11="no"
     xv="no"
@@ -695,8 +701,13 @@ if test "$xrender" = "yes" ; then
 fi
 
 if test "$tiny" = "yes" ; then
-  echo "#define CONFIG_TINY 1" >> $TMPH
+  #echo "#define CONFIG_TINY 1" >> $TMPH
   echo "CONFIG_TINY=yes" >> $TMPMAK
+fi
+
+if test "$tiny_only" = "yes" ; then
+  #echo "#define CONFIG_TINY 1" >> $TMPH
+  echo "CONFIG_TINY_ONLY=yes" >> $TMPMAK
 fi
 
 if test "$html" = "yes" ; then

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -1522,6 +1522,46 @@ ModeDef cpp_mode = {
     .fallback = &c_mode,
 };
 
+/*---------------- C2 language ----------------*/
+
+static const char c2_keywords[] = {
+    // Module related
+    "module|import|as|public|"
+    // Types -> c2_types
+    // Type related
+    "asm|cast|const|elemsof|enum|extern|"
+    "false|fn|local|nil|offsetof|to_container|public|"
+    "sizeof|static|struct|template|tlocal|true|type|union|volatile|"
+    // Control flow related
+    "break|case|continue|default|else|fallthrough|"
+    "for|goto|if|return|switch|when|while|"
+    // other
+    "assert|static_assert|"
+    // C keywords (supported in extern "C" blocks)
+    "typedef|"
+    // C keywords (reserved)
+    "alignas|alignof|auto|constexpr|do|inline|nullptr|"
+    "register|restrict|thread_local|typeof|typeof_unqual"
+};
+
+static const char c2_types[] = {
+    "void|bool|char|i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64|"
+    "reg8|reg16|reg32|reg64|va_list|"
+    "int|short|long|float|double|signed|unsigned|size_t|ssize_t"
+};
+
+static ModeDef c2_mode = {
+    .name = "C2",
+    .extensions = "c2|c2h|c2i|c2t",
+    .colorize_func = c_colorize_line,
+    .colorize_flags = CLANG_C2 | CLANG_PREPROC | CLANG_CAP_TYPE,
+    .keywords = c2_keywords,
+    .types = c2_types,
+    .indent_func = c_indent_line,
+    .auto_indent = 1,
+    .fallback = &c_mode,
+};
+
 #ifndef CONFIG_TINY
 /*---------------- Carbon programming language ----------------*/
 
@@ -1571,46 +1611,6 @@ static ModeDef carbon_mode = {
     .colorize_flags = CLANG_CARBON | CLANG_STR3,
     .keywords = carbon_keywords,
     .types = carbon_types,
-    .indent_func = c_indent_line,
-    .auto_indent = 1,
-    .fallback = &c_mode,
-};
-
-/*---------------- C2 language ----------------*/
-
-static const char c2_keywords[] = {
-    // Module related
-    "module|import|as|public|"
-    // Types -> c2_types
-    // Type related
-    "asm|cast|const|elemsof|enum|extern|"
-    "false|fn|local|nil|offsetof|to_container|public|"
-    "sizeof|static|struct|template|tlocal|true|type|union|volatile|"
-    // Control flow related
-    "break|case|continue|default|else|fallthrough|"
-    "for|goto|if|return|switch|when|while|"
-    // other
-    "assert|static_assert|"
-    // C keywords (supported in extern "C" blocks)
-    "typedef|"
-    // C keywords (reserved)
-    "alignas|alignof|auto|constexpr|do|inline|nullptr|"
-    "register|restrict|thread_local|typeof|typeof_unqual"
-};
-
-static const char c2_types[] = {
-    "void|bool|char|i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64|"
-    "reg8|reg16|reg32|reg64|va_list|"
-    "int|short|long|float|double|signed|unsigned|size_t|ssize_t"
-};
-
-static ModeDef c2_mode = {
-    .name = "C2",
-    .extensions = "c2|c2h|c2i|c2t",
-    .colorize_func = c_colorize_line,
-    .colorize_flags = CLANG_C2 | CLANG_PREPROC | CLANG_CAP_TYPE,
-    .keywords = c2_keywords,
-    .types = c2_types,
     .indent_func = c_indent_line,
     .auto_indent = 1,
     .fallback = &c_mode,
@@ -2156,6 +2156,86 @@ ModeDef js_mode = {
     .fallback = &c_mode,
 };
 
+/*---------------- JSON data format ----------------*/
+
+static const char json_keywords[] = {
+    "null|true|false|NaN"
+};
+
+static const char json_types[] = {
+    ""
+};
+
+static int json_mode_probe(ModeDef *mode, ModeProbeData *pd)
+{
+    const char *p = cs8(pd->buf);
+
+    if (match_extension(pd->filename, mode->extensions))
+        return 80;
+
+    if (*p == '{' && p[1] == '\n') {
+        while (qe_isspace((unsigned char)*++p))
+            continue;
+        if (*p == '\"')
+            return 50;
+    }
+    return 1;
+}
+
+static ModeDef json_mode = {
+    .name = "json",
+    .extensions = "json",
+    .mode_probe = json_mode_probe,
+    .colorize_func = js_colorize_line,
+    .colorize_flags = CLANG_JSON,
+    .keywords = json_keywords,
+    .types = json_types,
+    .indent_func = c_indent_line,
+    .auto_indent = 1,
+    .fallback = &c_mode,
+};
+
+/*---------------- Typescript programming language ----------------*/
+
+static const char ts_keywords[] = {
+    /* keywords */
+    "break|case|catch|class|const|continue|debugger|default|"
+    "delete|do|else|enum|export|extends|false|finally|"
+    "for|function|if|import|in|instanceof|new|null|"
+    "return|super|switch|this|throw|true|try|typeof|"
+    "var|void|while|with|"
+    /* keywords in strict mode */
+    "implements|interface|let|package|"
+    "private|protected|public|static|yield|"
+    /* special names */
+    "abstract|as|async|await|constructor|declare|from|"
+    "get|is|module|namespace|of|require|set|type|"
+    /* other names? */
+    "readonly|"
+    /* constants */
+    "undefined|Infinity|NaN|"
+    /* strict mode quasi keywords */
+    "eval|arguments|"
+};
+
+static const char ts_types[] = {
+    "any|boolean|number|string|symbol|"
+};
+
+static ModeDef ts_mode = {
+    .name = "TypeScript",
+    .alt_name = "ts",
+    .extensions = "ts|tsx",
+    //.shell_handlers = "ts",
+    .colorize_func = js_colorize_line,
+    .colorize_flags = CLANG_TS | CLANG_REGEX,
+    .keywords = ts_keywords,
+    .types = ts_types,
+    .indent_func = c_indent_line,
+    .auto_indent = 1,
+    .fallback = &c_mode,
+};
+
 #ifndef CONFIG_TINY
 /*---------------- V8 Torque programming language ----------------*/
 
@@ -2229,47 +2309,6 @@ ModeDef css_mode = {
     .keywords = css_keywords,
     .types = css_types,
     .indent_func = c_indent_line,
-    .fallback = &c_mode,
-};
-
-/*---------------- Typescript programming language ----------------*/
-
-static const char ts_keywords[] = {
-    /* keywords */
-    "break|case|catch|class|const|continue|debugger|default|"
-    "delete|do|else|enum|export|extends|false|finally|"
-    "for|function|if|import|in|instanceof|new|null|"
-    "return|super|switch|this|throw|true|try|typeof|"
-    "var|void|while|with|"
-    /* keywords in strict mode */
-    "implements|interface|let|package|"
-    "private|protected|public|static|yield|"
-    /* special names */
-    "abstract|as|async|await|constructor|declare|from|"
-    "get|is|module|namespace|of|require|set|type|"
-    /* other names? */
-    "readonly|"
-    /* constants */
-    "undefined|Infinity|NaN|"
-    /* strict mode quasi keywords */
-    "eval|arguments|"
-};
-
-static const char ts_types[] = {
-    "any|boolean|number|string|symbol|"
-};
-
-static ModeDef ts_mode = {
-    .name = "TypeScript",
-    .alt_name = "ts",
-    .extensions = "ts|tsx",
-    //.shell_handlers = "ts",
-    .colorize_func = js_colorize_line,
-    .colorize_flags = CLANG_TS | CLANG_REGEX,
-    .keywords = ts_keywords,
-    .types = ts_types,
-    .indent_func = c_indent_line,
-    .auto_indent = 1,
     .fallback = &c_mode,
 };
 
@@ -2374,45 +2413,6 @@ static ModeDef koka_mode = {
     .colorize_flags = CLANG_KOKA | CLANG_REGEX | CLANG_NEST_COMMENTS,
     .keywords = koka_keywords,
     .types = koka_types,
-    .indent_func = c_indent_line,
-    .auto_indent = 1,
-    .fallback = &c_mode,
-};
-
-/*---------------- JSON data format ----------------*/
-
-static const char json_keywords[] = {
-    "null|true|false|NaN"
-};
-
-static const char json_types[] = {
-    ""
-};
-
-static int json_mode_probe(ModeDef *mode, ModeProbeData *pd)
-{
-    const char *p = cs8(pd->buf);
-
-    if (match_extension(pd->filename, mode->extensions))
-        return 80;
-
-    if (*p == '{' && p[1] == '\n') {
-        while (qe_isspace((unsigned char)*++p))
-            continue;
-        if (*p == '\"')
-            return 50;
-    }
-    return 1;
-}
-
-static ModeDef json_mode = {
-    .name = "json",
-    .extensions = "json",
-    .mode_probe = json_mode_probe,
-    .colorize_func = js_colorize_line,
-    .colorize_flags = CLANG_JSON,
-    .keywords = json_keywords,
-    .types = json_types,
     .indent_func = c_indent_line,
     .auto_indent = 1,
     .fallback = &c_mode,
@@ -4746,24 +4746,24 @@ static int c_init(QEmacsState *qs)
     qe_register_commands(qs, &c_mode, c_commands, countof(c_commands));
     qe_register_mode(qs, &cpp_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &js_mode, MODEF_SYNTAX);
+    qe_register_mode(qs, &json_mode, MODEF_SYNTAX);
+    qe_register_mode(qs, &ts_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &java_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &php_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &go_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &yacc_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &lex_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &csharp_mode, MODEF_SYNTAX);
+    qe_register_mode(qs, &c2_mode, MODEF_SYNTAX);
 #ifndef CONFIG_TINY
     qe_register_mode(qs, &v8_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &bee_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &idl_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &carbon_mode, MODEF_SYNTAX);
-    qe_register_mode(qs, &c2_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &objc_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &awk_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &css_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &less_mode, MODEF_SYNTAX);
-    qe_register_mode(qs, &json_mode, MODEF_SYNTAX);
-    qe_register_mode(qs, &ts_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &jspp_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &koka_mode, MODEF_SYNTAX);
     qe_register_mode(qs, &as_mode, MODEF_SYNTAX);


### PR DESCRIPTION
Clarify tiny build options:
* distinguish `tiny` which controls whether the tiny version should be built
* and `tiny_only` which restricts the build to just the tiny version
* add `--disable-tiny` to set `tiny=no`
* add `--tiny-only` to only build the tiny version
* add js, json and c2 modes in tiny version