### PR TITLE
input: add select-input-method command

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -1976,6 +1976,10 @@ static void do_describe_window(EditState *s, int argval)
     eb_printf(b1, "%*s: %d\n", w, "unihex_mode", s->unihex_mode);
     eb_printf(b1, "%*s: %d\n", w, "hex_nibble", s->hex_nibble);
     eb_printf(b1, "%*s: %d\n", w, "overwrite", s->overwrite);
+    if (s->input_method)
+        eb_printf(b1, "%*s: %s\n", w, "input_method", s->input_method->name);
+    if (s->selected_input_method)
+        eb_printf(b1, "%*s: %s\n", w, "selected_input_method", s->selected_input_method->name);
     eb_printf(b1, "%*s: %d\n", w, "bidir", s->bidir);
     eb_printf(b1, "%*s: %d\n", w, "cur_rtl", s->cur_rtl);
     eb_printf(b1, "%*s: %u  %s\n", w, "wrap", s->wrap,

--- a/input.c
+++ b/input.c
@@ -111,7 +111,18 @@ void do_set_input_method(EditState *s, const char *name)
         s->input_method = m;
         s->selected_input_method = m;
     } else {
-        put_error(s, "'%s' not found", name);
+        put_error(s, "Cannot set input method '%s': not found", name);
+    }
+}
+
+void do_select_input_method(EditState *s, const char *name)
+{
+    InputMethod *m = qe_find_input_method(s->qs, name);
+
+    if (m) {
+        s->selected_input_method = m;
+    } else {
+        put_error(s, "Cannot select input method '%s': not found", name);
     }
 }
 

--- a/qe.c
+++ b/qe.c
@@ -11558,14 +11558,18 @@ static const CmdDef basic_commands[] = {
           do_convert_buffer_file_coding_system, ESs, "*"
           "s{Charset: }[charset]|charset|")
     CMD0( "toggle-bidir", "C-x RET b, C-c b",
-          "",
+          "Toggle bidirectional text rendering",
           do_toggle_bidir)
     CMD2( "set-input-method", "C-x RET C-\\, C-c C-\\",
-          "",
+          "Set and activate the window input method",
           do_set_input_method, ESs,
           "s{Input method: }[input]")
+    CMD2( "select-input-method", "",
+          "Set the window input method without activating it",
+          do_select_input_method, ESs,
+          "s{Input method: }[input]")
     CMD0( "switch-input-method", "C-x C-\\",
-          "",
+          "Toggle the window input method",
           do_switch_input_method)
 
     /*---------------- Styles & display ----------------*/

--- a/qe.h
+++ b/qe.h
@@ -1402,6 +1402,7 @@ struct InputMethod {
 
 void qe_register_input_method(QEmacsState *qs, InputMethod *m);
 void do_set_input_method(EditState *s, const char *method);
+void do_select_input_method(EditState *s, const char *method);
 void do_switch_input_method(EditState *s);
 void qe_input_methods_init(QEmacsState *qs);
 int qe_load_input_methods(QEmacsState *qs, const char *filename);


### PR DESCRIPTION
I think setting a configuration variable might be a better option but I added `select-input-method` to be consistent with the example configuration file:

```c
  // set default input method
  set_input_method("HebrewIsraeli");
```