### PR TITLE
fixes in compare-windows and variable completion popup

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -250,24 +250,25 @@ void do_compare_windows(EditState *s, int argval)
             continue;
         break;
     }
-    if (argval == 0) {
-        qs->ignore_spaces = 0;
-        qs->ignore_comments = 0;
-        qs->ignore_case = 0;
-        qs->ignore_preproc = 0;
-        qs->ignore_equivalent = 0;
+    if (argval != NO_ARG) {
+        if (argval == 0) {
+            qs->ignore_spaces = 0;
+            qs->ignore_comments = 0;
+            qs->ignore_case = 0;
+            qs->ignore_preproc = 0;
+            qs->ignore_equivalent = 0;
+        }
+        if (argval & 4)
+            qs->ignore_spaces ^= 1;
+        if (argval & 16)
+            qs->ignore_comments ^= 1;
+        if (argval & 64)
+            qs->ignore_case ^= 1;
+        if (argval & 256)
+            qs->ignore_preproc ^= 1;
+        if (argval & 1024)
+            qs->ignore_equivalent ^= 1;
     }
-    if (argval & 4)
-        qs->ignore_spaces ^= 1;
-    if (argval & 16)
-        qs->ignore_comments ^= 1;
-    if (argval & 64)
-        qs->ignore_case ^= 1;
-    if (argval & 256)
-        qs->ignore_preproc ^= 1;
-    if (argval & 1024)
-        qs->ignore_equivalent ^= 1;
-
     size1 = s1->b->total_size;
     size2 = s2->b->total_size;
 

--- a/variables.c
+++ b/variables.c
@@ -558,8 +558,8 @@ int eb_variable_print_entry(EditBuffer *b, VarDef *vp, EditState *s) {
         b->cur_style = QE_STYLE_NUMBER;
     len += eb_puts(b, buf);
     b->cur_style = QE_STYLE_COMMENT;
-    if (len + 1 < 40) {
-        b->tab_width = max_int(len + 1, b->tab_width);
+    if (len + 2 <= 40) {
+        b->tab_width = max_int(len + 2, b->tab_width);
         len += eb_putc(b, '\t');
     } else {
         b->tab_width = 40;


### PR DESCRIPTION
* `compare-windows` used to toggle all ignore flags if invoked without an argument. This was bogus.
* when reading a variable name (eg: `eval-expression`), improve alignment of variable descriptions in popup window