### PR TITLE
Simplify mode probing

### DIFF
--- a/color.h
+++ b/color.h
@@ -2,7 +2,7 @@
  * Color / CSS Utilities for qemacs.
  *
  * Copyright (c) 2000-2001 Fabrice Bellard.
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/cutils.h
+++ b/cutils.h
@@ -2,7 +2,7 @@
  * Various simple C utilities
  *
  * Copyright (c) 2000-2002 Fabrice Bellard.
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/display.c
+++ b/display.c
@@ -2,7 +2,7 @@
  * Display system for QEmacs
  *
  * Copyright (c) 2000 Fabrice Bellard.
- * Copyright (c) 2002-2024 Charlie Gordon.
+ * Copyright (c) 2002-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lang/clang.c
+++ b/lang/clang.c
@@ -3019,10 +3019,8 @@ static const char qs_types[] = {
 static int qs_mode_probe(ModeDef *mode, ModeProbeData *p)
 {
     if (match_extension(p->filename, mode->extensions)
-    ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)) {
-        return 80;
-    }
-    if (strequal(p->filename, ".qerc")
+    ||  match_filename(p->filename, mode->filenames)
+    ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)
     ||  strstr(p->real_filename, "/.qe/config"))
         return 80;
 
@@ -3033,6 +3031,7 @@ static ModeDef qscript_mode = {
     .name = "QScript",
     .alt_name = "qs",
     .extensions = "qe|qs",
+    .filenames = ".qerc",
     .shell_handlers = "qscript|qs|qsn",
     .mode_probe = qs_mode_probe,
     .colorize_func = js_colorize_line,

--- a/lang/coffee.c
+++ b/lang/coffee.c
@@ -1,7 +1,7 @@
 /*
  * Coffee script language mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -355,22 +355,12 @@ static void coffee_colorize_line(QEColorizeContext *cp,
     cp->colorize_state = state;
 }
 
-static int coffee_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    if (match_extension(p->filename, mode->extensions)
-    ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)
-    ||  stristart(p->filename, "Cakefile", NULL)) {
-        return 80;
-    }
-    return 1;
-}
-
 static ModeDef coffee_mode = {
     .name = "CoffeeScript",
     .alt_name = "coffee",
     .extensions = "coffee",
+    .filenames = "Cakefile",
     .shell_handlers = "coffee",
-    .mode_probe = coffee_mode_probe,
     .keywords = coffee_keywords,
     .colorize_func = coffee_colorize_line,
 };

--- a/lang/lisp.c
+++ b/lang/lisp.c
@@ -1,7 +1,7 @@
 /*
  * Lisp Source mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -461,17 +461,6 @@ static void lisp_colorize_line(QEColorizeContext *cp,
     cp->colorize_state = colstate;
 }
 
-static int elisp_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    /* check file name or extension */
-    if (match_extension(p->filename, mode->extensions)
-    ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)
-    ||  strstart(p->filename, ".emacs", NULL))
-        return 80;
-
-    return 1;
-}
-
 ModeDef lisp_mode = {
     .name = "Lisp",
     .extensions = "ll|li|lh|lo|lm|lisp|ls9",
@@ -485,9 +474,9 @@ ModeDef lisp_mode = {
 static ModeDef elisp_mode = {
     .name = "ELisp",
     .extensions = "el",
+    .filenames = ".emacs",
     .keywords = elisp_keywords,
     .types = elisp_types,
-    .mode_probe = elisp_mode_probe,
     .colorize_func = lisp_colorize_line,
     .colorize_flags = LISP_LANG_ELISP,
     .fallback = &lisp_mode,

--- a/lang/makemode.c
+++ b/lang/makemode.c
@@ -1,7 +1,7 @@
 /*
  * Makefile mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -136,17 +136,6 @@ static void makefile_colorize_line(QEColorizeContext *cp,
     }
 }
 
-static int makefile_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    /* check file name or extension */
-    if (match_extension(p->filename, mode->extensions)
-    ||  stristart(p->filename, "makefile", NULL)
-    ||  stristart(p->filename, "gnumakefile", NULL))
-        return 70;
-
-    return 1;
-}
-
 static int makefile_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
@@ -160,7 +149,7 @@ static int makefile_mode_init(EditState *s, EditBuffer *b, int flags)
 static ModeDef makefile_mode = {
     .name = "Makefile",
     .extensions = "mak|make|mk|gmk",
-    .mode_probe = makefile_mode_probe,
+    .filenames = "makefile|gnumakefile",
     .mode_init = makefile_mode_init,
     .colorize_func = makefile_colorize_line,
 };
@@ -243,20 +232,10 @@ static void cmake_colorize_line(QEColorizeContext *cp,
     }
 }
 
-static int cmake_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    /* check file name or extension */
-    if (match_extension(p->filename, mode->extensions)
-    ||  stristart(p->filename, "cmakelists.txt", NULL))
-        return 70;
-
-    return 1;
-}
-
 static ModeDef cmake_mode = {
     .name = "CMake",
     .extensions = "cmake",
-    .mode_probe = cmake_mode_probe,
+    .filenames = "cmakelists.txt",
     .colorize_func = cmake_colorize_line,
 };
 

--- a/lang/python.c
+++ b/lang/python.c
@@ -1,7 +1,7 @@
 /*
  * Python language mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -351,16 +351,6 @@ static ModeDef rapydscript_mode = {
 
 /*---- Bazel mode: a build system with a Python-like syntax ----*/
 
-static int bazel_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    /* check file name or extension */
-    if (match_extension(p->filename, mode->extensions)
-    ||  strstart(p->filename, "WORKSPACE", NULL))
-        return 70;
-
-    return 1;
-}
-
 static int bazel_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
@@ -374,8 +364,8 @@ static int bazel_mode_init(EditState *s, EditBuffer *b, int flags)
 static ModeDef bazel_mode = {
     .name = "Bazel",
     .extensions = "bzl|bazel",
+    .filenames = "WORKSPACE",
     .keywords = python_keywords,
-    .mode_probe = bazel_mode_probe,
     .mode_init = bazel_mode_init,
     .colorize_func = python_colorize_line,
     .colorize_flags = PYTHON_BAZEL,

--- a/lang/ruby.c
+++ b/lang/ruby.c
@@ -1,7 +1,7 @@
 /*
  * Ruby language mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -487,21 +487,11 @@ static void ruby_colorize_line(QEColorizeContext *cp,
     cp->colorize_state = state;
 }
 
-static int ruby_mode_probe(ModeDef *mode, ModeProbeData *p)
-{
-    if (match_extension(p->filename, mode->extensions)
-    ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)
-    ||  stristart(p->filename, "Rakefile", NULL)) {
-        return 80;
-    }
-    return 1;
-}
-
 static ModeDef ruby_mode = {
     .name = "Ruby",
     .extensions = "rb|gemspec",
+    .filenames = "Rakefile",
     .shell_handlers = "ruby",
-    .mode_probe = ruby_mode_probe,
     .keywords = ruby_keywords,
     .colorize_func = ruby_colorize_line,
 };

--- a/lang/script.c
+++ b/lang/script.c
@@ -1,7 +1,7 @@
 /*
  * Shell script mode for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -279,7 +279,7 @@ static int shell_script_mode_probe(ModeDef *mode, ModeProbeData *p)
         return 82;
     }
 
-    if (stristart(p->filename, ".profile", NULL)) {
+    if (match_filename(p->filename, mode->filenames)) {
         /* XXX: Should check the user login shell */
         return 80;
     }
@@ -298,6 +298,7 @@ static ModeDef sh_mode = {
     .name = "ShellScript",
     .alt_name = "sh",
     .extensions = "sh",
+    .filenames = ".profile",
     .shell_handlers = "sh",
     .mode_probe = shell_script_mode_probe,
     .colorize_func = shell_script_colorize_line,
@@ -307,6 +308,7 @@ static ModeDef sh_mode = {
 static ModeDef bash_mode = {
     .name = "bash",
     .extensions = "bash",
+    .filenames = ".bashrc|.bash_history",
     .shell_handlers = "bash",
     .mode_probe = shell_script_mode_probe,
     .colorize_func = shell_script_colorize_line,

--- a/lang/sharp.c
+++ b/lang/sharp.c
@@ -1,7 +1,7 @@
 /*
  * Sharp mode (generic unix script colorizer) modes for QEmacs.
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -88,8 +88,7 @@ static int sharp_mode_probe(ModeDef *mode, ModeProbeData *pd)
 {
     const char *p = cs8(pd->buf);
 
-    if (stristart(pd->filename, ".gitignore", NULL)
-    ||  stristart(pd->filename, ".clang-format", NULL))
+    if (match_filename(pd->filename, mode->filenames))
         return 70;
 
     while (qe_isspace(*p))
@@ -105,6 +104,7 @@ static int sharp_mode_probe(ModeDef *mode, ModeProbeData *pd)
 
 static ModeDef sharp_mode = {
     .name = "sharp",
+    .filenames = ".gitignore|.clang-format|COMMIT_EDITMSG",
     .mode_probe = sharp_mode_probe,
     .colorize_flags = 0,
     .colorize_func = sharp_colorize_line,
@@ -125,17 +125,9 @@ static ModeDef yaml_mode = {
 
 /* Very simple colorizer: comments, strings, config */
 
-static int recipe_mode_probe(ModeDef *mode, ModeProbeData *pd)
-{
-    if (stristart(pd->filename, "recipe.txt", NULL))
-        return 70;
-
-    return 1;
-}
-
 static ModeDef recipe_mode = {
     .name = "C2-recipe",
-    .mode_probe = recipe_mode_probe,
+    .filenames = "recipe.txt",
     .colorize_flags = SHARP_STRING1 | SHARP_STRING2 | SHARP_CONFIG,
     .colorize_func = sharp_colorize_line,
 };

--- a/lang/tcl.c
+++ b/lang/tcl.c
@@ -1,7 +1,7 @@
 /*
  * TCL language mode for QEmacs.
  *
- * Copyright (c) 2025 Charlie Gordon.
+ * Copyright (c) 2025-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -343,7 +343,7 @@ dispatch_colstate:
 
 static int tcl_mode_probe(ModeDef *mode, ModeProbeData *p) {
     if (match_extension(p->filename, mode->extensions)
-    ||  strstart(p->filename, "tclIndex", NULL))
+    ||  match_filename(p->filename, mode->filenames))
         return 85;
 
     if (strstr(cs8(p->buf), "package require Tk")
@@ -361,9 +361,10 @@ static int tcl_mode_probe(ModeDef *mode, ModeProbeData *p) {
 static ModeDef tcl_mode = {
     .name = "Tcl",
     .extensions = "tcl",
+    .filenames = "tclIndex",
     .keywords = tcl_keywords,
-    .colorize_func = tcl_colorize_line,
     .mode_probe = tcl_mode_probe,
+    .colorize_func = tcl_colorize_line,
 };
 
 static int tcl_init(QEmacsState *qs) {

--- a/lang/xml.c
+++ b/lang/xml.c
@@ -2,7 +2,7 @@
  * XML text mode for QEmacs.
  *
  * Copyright (c) 2002 Fabrice Bellard.
- * Copyright (c) 2014-2024 Charlie Gordon.
+ * Copyright (c) 2014-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -180,6 +180,9 @@ static int xml_mode_probe(ModeDef *mode, ModeProbeData *p1)
 {
     const u8 *p;
 
+    if (match_extension(p1->filename, mode->extensions))
+        return 70;
+
     p = p1->buf;
     while (qe_isspace(*p))
         p++;
@@ -194,6 +197,7 @@ static int xml_mode_probe(ModeDef *mode, ModeProbeData *p1)
 
 ModeDef xml_mode = {
     .name = "xml",
+    .extensions = "xml",
     .mode_probe = xml_mode_probe,
     .colorize_func = xml_colorize_line,
 };

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -2169,6 +2169,12 @@ list pointed to by `extlist`.
 * Initial dots do not account as extension delimiters.
 * `.` and `..` do not have an empty extension, nor do they match `||`
 
+### `int match_filename(const char *filename, const char *namespec);`
+
+Return `true` iff the filename appears in `|` separated
+list pointed to by `namespec`.
+* Initial and final `|` are ignored as well as `||`.
+
 ### `int match_shell_handler(const char *p, const char *list);`
 
 Return `true` iff the command name invoked by the `#!` line pointed to by `p`

--- a/qe.c
+++ b/qe.c
@@ -81,6 +81,7 @@ static int default_mode_init(EditState *s, EditBuffer *b, int flags) { return 0;
 static int generic_mode_probe(ModeDef *mode, ModeProbeData *p)
 {
     if (match_extension(p->filename, mode->extensions)
+    ||  match_filename(p->filename, mode->filenames)
     ||  match_shell_handler(cs8(p->buf), mode->shell_handlers)) {
         return 80;
     }
@@ -108,10 +109,11 @@ ModeDef *qe_find_mode_filename(QEmacsState *qs, const char *filename, int flags)
     ModeDef *m;
 
     for (m = qs->first_mode; m; m = m->next) {
-        // XXX: should have a filenames field to match basenames
-        if ((m->flags & flags) == flags
-        &&  match_extension(filename, m->extensions)) {
-            break;
+        if ((m->flags & flags) == flags) {
+            if (match_extension(filename, m->extensions)
+            ||  match_filename(filename, m->filenames)) {
+                break;
+            }
         }
     }
     return m;

--- a/qe.h
+++ b/qe.h
@@ -852,6 +852,7 @@ struct ModeDef {
     const char *alt_name;       /* alternate name, for the mode setting cmd */
     const char *desc;           /* description of the mode */
     const char *extensions;
+    const char *filenames;
     const char *shell_handlers;
     const char *keywords;       /* list of keywords for a language mode */
     const char *types;          /* list of types for a language mode */

--- a/qescript.c
+++ b/qescript.c
@@ -2,7 +2,7 @@
  * QEmacs, tiny but powerful multimode editor
  *
  * Copyright (c) 2000-2002 Fabrice Bellard.
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tty.c
+++ b/tty.c
@@ -2,7 +2,7 @@
  * TTY Terminal handling for QEmacs
  *
  * Copyright (c) 2000-2001 Fabrice Bellard.
- * Copyright (c) 2002-2024 Charlie Gordon.
+ * Copyright (c) 2002-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/util.c
+++ b/util.c
@@ -487,6 +487,7 @@ int match_extension(const char *filename, const char *extlist) {
     if (len == 0)
         return 0;
 
+    // XXX: need syntax to select case ignore and multiple patterns
     for (p = q = extlist;; p++) {
         int c = *p;
         if (c == '|' || c == '\0') {
@@ -497,10 +498,44 @@ int match_extension(const char *filename, const char *extlist) {
                     return 1;
                 }
             }
-            if (c == '|')
-                q = p + 1;
-            else
+            if (c == '\0')
                 break;
+            q = p + 1;
+        }
+    }
+    return 0;
+}
+
+int match_filename(const char *filename, const char *namespec) {
+    /*@API utils
+       Return `true` iff the filename appears in `|` separated
+       list pointed to by `namespec`.
+     * Initial and final `|` are ignored as well as `||`.
+     */
+    const char *base, *p, *q;
+    int len;
+
+    if (!namespec)
+        return 0;
+
+    base = get_basename(filename);
+    len = strlen(base);
+    if (len == 0)
+        return 0;
+
+    // XXX: need syntax to select case ignore and multiple patterns
+    for (p = q = namespec;; p++) {
+        int c = *p;
+        if (c == '|' || c == '\0') {
+            int len1 = p - q;
+            if (len1 != 0) {
+                // XXX: accept trailing `*` or richer regex
+                if (len == len1 && !qe_memicmp(base, q, len1))
+                    return 1;
+            }
+            if (c == '\0')
+                break;
+            q = p + 1;
         }
     }
     return 0;

--- a/util.h
+++ b/util.h
@@ -66,6 +66,7 @@ char *make_user_path(char *buf, int buf_size, const char *path);
 char *reduce_filename(char *dest, int size, const char *filename);
 char *file_load(const char *filename, int max_size, int *sizep);
 int match_extension(const char *filename, const char *extlist);
+int match_filename(const char *filename, const char *namespec);
 int match_shell_handler(const char *p, const char *list);
 // XXX: should move these to cutils?
 int remove_slash(char *buf);

--- a/variables.c
+++ b/variables.c
@@ -1,7 +1,7 @@
 /*
  * Module for handling variables in QEmacs
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/variables.h
+++ b/variables.h
@@ -1,7 +1,7 @@
 /*
  * Module for handling variables in QEmacs
  *
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/x11.c
+++ b/x11.c
@@ -2,7 +2,7 @@
  * X11 handling for QEmacs
  *
  * Copyright (c) 2000-2003 Fabrice Bellard.
- * Copyright (c) 2002-2025 Charlie Gordon.
+ * Copyright (c) 2002-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* add `filenames` specification in `ModeDef` structures
* generic mode probing can match a list of filenames
* remove unneeded mode_probe functions
* this enables diff coloring on Makefile