### PR TITLE
Shell improvements

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -833,7 +833,7 @@ void eb_free(EditBuffer **bp)
             qe_free(&cb);
         }
 
-        eb_delete_properties(b, 0, INT_MAX);
+        eb_delete_properties(b, 0, INT_MAX, 1);
         eb_cache_remove(b);
         /* eb_clear frees b->log_buffer.
          * it should also call eb_free_style_buffer(b)
@@ -2834,7 +2834,7 @@ QEProperty *eb_find_property(EditBuffer *b, int offset, int offset2, int type) {
     return found;
 }
 
-void eb_delete_properties(EditBuffer *b, int offset, int offset2) {
+void eb_delete_properties(EditBuffer *b, int offset, int offset2, int force) {
     QEProperty *p;
     QEProperty **pp;
 
@@ -2842,7 +2842,7 @@ void eb_delete_properties(EditBuffer *b, int offset, int offset2) {
         return;
 
     for (pp = &b->property_list; (p = *pp) != NULL && p->offset < offset2;) {
-        if (p->offset >= offset && p->offset < offset2) {
+        if ((!(p->type & QE_PROP_SKIP) || force) && p->offset >= offset) {
             *pp = (*pp)->next;
             if (p->type & QE_PROP_FREE) {
                 qe_free(&p->data);

--- a/extras.c
+++ b/extras.c
@@ -1967,6 +1967,8 @@ static void do_describe_buffer(EditState *s, int argval)
         buf_puts(desc, " SAVING");
     if (b->flags & BF_DIRED)
         buf_puts(desc, " DIRED");
+    if (b->flags & BF_SHELL)
+        buf_puts(desc, " SHELL");
     if (b->flags & BF_UTF8)
         buf_puts(desc, " UTF8");
     if (b->flags & BF_RAW)

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2789,8 +2789,10 @@ static void do_shell(EditState *e, int argval)
     char curpath[MAX_FILENAME_SIZE];
     EditBuffer *b = NULL;
 
-    if (e->flags & (WF_POPUP | WF_MINIBUF))
+    if (e->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(e, "%s", "Please start command in a normal window");
         return;
+    }
 
     /* Start the shell in the default directory of the current window */
     get_default_path(e->b, e->offset, curpath, sizeof curpath);
@@ -2911,8 +2913,10 @@ static void do_man(EditState *s, const char *arg)
     QEmacsState *qs = s->qs;
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF))
+    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(s, "%s", "Please start command in a normal window");
         return;
+    }
 
     if (s->flags & WF_POPLEFT) {
         /* avoid messing with the dired pane */
@@ -2951,8 +2955,11 @@ void qe_diff_buffer_with_file(EditState *s, EditBuffer *b)
     const char *tmpdir = getenv("TMPDIR");
     int tmpdir_len;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF))
+    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(s, "%s", "Please start command in a normal window");
         return;
+    }
+
     if (!*fname)
         return;
 
@@ -3017,8 +3024,10 @@ static void do_ssh(EditState *s, const char *arg)
     QEmacsState *qs = s->qs;
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF))
+    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(s, "%s", "Please start command in a normal window");
         return;
+    }
 
     if (s->flags & WF_POPLEFT) {
         /* avoid messing with the dired pane */
@@ -3705,8 +3714,10 @@ static void do_compile(EditState *s, const char *cmd)
     const char *bufname = "*compilation*";
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF))
+    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(s, "%s", "Please start command in a normal window");
         return;
+    }
 
     get_default_path(s->b, s->offset, curpath, sizeof curpath);
 

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -4063,10 +4063,11 @@ static int shell_grab_filename(const char32_t *buf, int n,
     return i;
 }
 
-#define STATE_SHELL_SHIFT  7
+#define STATE_SHELL_SHIFT  8
 #define STATE_SHELL_MODE   0x001F
 #define STATE_SHELL_SKIP   0x0020
 #define STATE_SHELL_KEEP   0x0040
+#define STATE_SHELL_TAG    0x0080
 #define STATE_SHELL_MASK   ((1 << STATE_SHELL_SHIFT) - 1)
 
 static ModeDef *mode_cache[STATE_SHELL_MODE + 1];
@@ -4220,25 +4221,26 @@ void shell_colorize_line(QEColorizeContext *cp,
                     c = str[i];
                     if (c == '(') {
                         /* this is an old style filename position */
+                        i += 1;
                         i += match_digits(str + i, n - i, ')');
                         i += (str[i] == ':');
-                        cp->colorize_state = mc;
+                        cp->colorize_state = mc | STATE_SHELL_TAG;
                         start = i;
                         break;
                     }
                     /* colorize compiler and grep -[ABC] output */
                     if (c == ':' || (c == '-' && qe_isdigit(str[i + 1]))) {
                         /* this is a compiler message */
+                        i += 1;
                         i += match_digits(str + i, n - i, c); /* line number */
                         i += match_digits(str + i, n - i, c); /* optional col number */
                         start = i;
-                        cp->colorize_state = mc;
+                        cp->colorize_state = mc | STATE_SHELL_TAG;
                         if (match_string(str + i, n - i, " error:")
                         ||  match_string(str + i, n - i, " note:")
                         ||  match_string(str + i, n - i, " warning:")) {
                             /* clang diagnostic, will colorize the next line */
                             start = n;
-                            return;
                         }
                         break;
                     }
@@ -4260,7 +4262,12 @@ void shell_colorize_line(QEColorizeContext *cp,
         } else {
             cp->colorize_state = 0;
         }
-        cp->combine_stop = start;
+        if (save_state & STATE_SHELL_TAG) {
+            SET_STYLE(sbuf, 0, i, QE_STYLE_ERROR_LOCATION);
+            cp->combine_stop = 0;
+        } else {
+            cp->combine_stop = start;
+        }
         cp->combine_skip = start; // restrict trailing blank colorizer
     } else {
         cp->colorize_state = 0;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2856,6 +2856,55 @@ static EditBuffer *try_show_buffer(EditState **sp, const char *bufname)
 
 static void do_shell(EditState *e, int argval)
 {
+    /*@CMD shell
+       ### `shell(int argval)`
+
+       Start a shell buffer or move to the last shell buffer used.
+       If a argval is provided and equal to one, the command attempts
+       to switch to an existing, active shell buffer. If the process has
+       already terminated, it will restart the shell in the original directory.
+       If no shell buffer exists, or argval is not equal to one, it starts a
+       new shell in the default directory of the current window.
+
+       ### Current Working Directory Synchronization
+
+       QEmacs supports tracking the current working directory of the shell
+       through OSC 7 escape sequences. This allows commands such as
+       `next-error` to resolve relative file names against the directory
+       reported by the shell.
+
+       To enable this feature, add an OSC 7 hook to your shell's startup
+       file. The examples below emit an OSC 7 sequence before each prompt
+       when running inside QEmacs:
+
+       **Bash:**
+       ```bash
+       if [ "$TERM_PROGRAM" = "qemacs" ]; then
+           export PROMPT_COMMAND='echo -ne "\e]7;file://${PWD}\a"'
+       fi
+       ```
+       **Zsh:**
+       ```zsh
+       if [ "$TERM_PROGRAM" = "qemacs" ]; then
+           function precmd() {
+               builtin print -Pn "\e]7;file://${PWD}\a"
+           }
+       fi
+       ```
+       **Fish:**
+       ```fish
+       if test "$TERM_PROGRAM" = "qemacs"
+           function sync_qemacs_shell --on-event=fish_prompt
+               printf "\e]7;file://$PWD\a"
+           end
+       end
+       ```
+       Other shells can be configured similarly by emitting:
+       `ESC ] 7 ; file://cwd BEL`
+
+       whenever the prompt is displayed or the current working
+       directory changes.
+     */
     char curpath[MAX_FILENAME_SIZE];
     EditBuffer *b = NULL;
 

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -45,6 +45,7 @@
 static ModeDef shell_mode, pager_mode;
 
 #define MAX_CSI_PARAMS  16
+#define MAX_OSC_SIZE    512 + MAX_FILENAME_SIZE
 
 enum QETermState {
     QE_TERM_STATE_NORM,
@@ -84,6 +85,8 @@ typedef struct ShellState {
     unsigned char term_buf[256];
     int term_len, term_pos;
     int utf8_len;
+    char osc_buf[MAX_OSC_SIZE];
+    int osc_len;
     EditBuffer *b;
     EditBuffer *b_color; /* color buffer, one byte per char */
     const char *ka1, *ka3, *kb2, *kc1, *kc3, *kcbt, *kspd;
@@ -97,7 +100,6 @@ typedef struct ShellState {
     const char *caption;  /* process caption for exit message */
     int shell_flags;
     int last_char;  /* last char sent to the process */
-    char curpath[MAX_FILENAME_SIZE]; /* should keep a list with validity ranges */
 } ShellState;
 
 typedef struct ShellError {
@@ -126,8 +128,6 @@ static ShellError error_state = {
 #define SR_REFRESH      2
 #define SR_SILENT       4
 static void do_shell_refresh(EditState *e, int flags);
-static char *shell_get_curpath(EditBuffer *b, int offset,
-                               char *buf, int buf_size);
 
 static void shell_close(ShellState *s);
 
@@ -1419,6 +1419,7 @@ static unsigned char const sco_color[16] = {
 
 static void qe_term_emulate(ShellState *s, int c)
 {
+    QEmacsState *qs = s->b->qs;
     int i, param1, param2, len, offset, offset1, offset2;
     ShellPos pos;
     char buf1[10];
@@ -1489,7 +1490,7 @@ static void qe_term_emulate(ShellState *s, int c)
             break;
         case 7:     /* BEL  Bell (Ctrl-G). */
             // XXX: should check for visible-bell
-            put_status(s->b->qs->active_window, "Ding!");
+            put_status(qs->active_window, "Ding!");
             break;
         case 8:     /* BS   Backspace (Ctrl-H). */
             //TRACE_PRINTF(s, "BS: ");
@@ -1673,6 +1674,7 @@ static void qe_term_emulate(ShellState *s, int c)
         case ']':   // Operating System Command (OSC is 0x9d).
             s->params[0] = 0;
             s->esc2 = 0;
+            s->osc_len = 0;
             s->state = QE_TERM_STATE_OSC1;
             break;
         case '^':   // Privacy Message (PM  is 0x9e).
@@ -1829,7 +1831,6 @@ static void qe_term_emulate(ShellState *s, int c)
         s->state = QE_TERM_STATE_STRING;
         /* fall thru */
     case QE_TERM_STATE_STRING:
-        /* CG: should store the string */
         /* Stop string on CR or LF, for protection */
         if ((c == '\012' || c == '\015') && s->params[0] != 1337) {
             s->state = QE_TERM_STATE_NORM;
@@ -1838,10 +1839,20 @@ static void qe_term_emulate(ShellState *s, int c)
         }
         /* Stop string on \a (^G) or ST (ESC \) */
         if (!(c == '\007' || c == 0234 || (s->lastc == 27 && c == '\\'))) {
-            /* XXX: should store the string for specific cases */
             s->lastc = c;
+            /* skip ';' following OSC number */
+            if (s->osc_len > 0 || (c != ';')) {
+                if (s->osc_len < countof(s->osc_buf) - 1)
+                    s->osc_buf[s->osc_len++] = c;
+            }
             break;
         }
+
+        /* if stopped on (ESC \) strip trailing ESC */
+        if (s->osc_len > 0 && s->osc_buf[s->osc_len - 1] == 27)
+            s->osc_len -= 1;
+
+        s->osc_buf[s->osc_len] = '\0';
         s->state = QE_TERM_STATE_NORM;
         /* OSC / PM / APC / DCS string has been received. Should handle these cases:
            - OSC 0; Pt ST  Change Icon Name and Window Title to Pt.
@@ -1889,7 +1900,62 @@ static void qe_term_emulate(ShellState *s, int c)
            xterm has a file download and image display protocol:
            - OSC 1337; Pt ST
          */
-        TRACE_PRINTF(s, "unhandled string: %.*s", min_int(s->term_pos, 20), s->term_buf);
+        switch (s->params[0]) {
+        case 7:
+            {
+                char cwd[MAX_FILENAME_SIZE];
+                buf_t cwdbuf[1];
+                int pos = 7; /* first character after "file://" */
+
+                if (!strstart(s->osc_buf, "file://", NULL)) {
+                    put_error(qs->active_window,
+                              "term_emulate: OSC 7 URI must start with 'file://'");
+                    break;
+                }
+
+                /* skip hostname if any */
+                while (pos < s->osc_len && s->osc_buf[pos] != '/')
+                    pos++;
+
+                if (pos >= s->osc_len) {
+                    put_error(qs->active_window,
+                              "term_emulate: missing path in OSC 7 URI: '%s'", s->osc_buf);
+                    break;
+                }
+                /* decode URI path */
+                buf_init(cwdbuf, cwd, sizeof(cwd));
+                while (pos < s->osc_len) {
+                    if (s->osc_buf[pos] == '%'
+                    && pos + 2 < s->osc_len
+                    && qe_isxdigit(s->osc_buf[pos + 1])
+                    && qe_isxdigit(s->osc_buf[pos + 2]))
+                    {
+                        buf_put_byte(cwdbuf, ((qe_digit_value(s->osc_buf[pos + 1]) << 4)
+                                           + qe_digit_value(s->osc_buf[pos + 2])));
+                        pos += 3;
+                    } else {
+                        buf_put_byte(cwdbuf, s->osc_buf[pos]);
+                        pos += 1;
+                    }
+                }
+                if (!strequal(s->b->filename, cwd)) {
+                    /* XXX: properties placed at end of buffer move forward whenever
+                       output is appended, causing successive cwd properties to share
+                       the same position instead of marking where cwd was observed. */
+                    int offset = s->b->offset - 1;
+                    if (offset > 0) { /* defer first property addition */
+                        if (!s->b->property_list && *s->b->filename)
+                            eb_add_property(s->b, 0, QE_PROP_CWD, qe_strdup(s->b->filename));
+                        eb_add_property(s->b, offset, QE_PROP_CWD, qe_strdup(cwd));
+                    }
+                    pstrcpy(unconst(char *)s->b->filename, sizeof(s->b->filename), cwd);
+                }
+            }
+            break;
+        default:
+            TRACE_PRINTF(s, "unhandled string: %s", s->osc_buf);
+            break;
+        }
         break;
     case QE_TERM_STATE_CSI:
         if (c >= '<' && c <= '?') {
@@ -2493,7 +2559,6 @@ static void shell_read_cb(void *opaque)
                 b->mark = s->cur_prompt;
             }
         }
-        shell_get_curpath(b, s->cur_offset, s->curpath, sizeof(s->curpath));
     } else {
         int pos = b->total_size;
         int threshold = 3 << 20;    /* 3MB for large pictures */
@@ -2706,6 +2771,8 @@ EditBuffer *qe_new_shell_buffer(QEmacsState *qs, EditBuffer *b0, EditState *e,
     }
     shell_flags &= ~(SF_REUSE_BUFFER | SF_ERASE_BUFFER);
 
+    if (path)
+        pstrcpy(unconst(char *)b->filename, sizeof(b->filename), path);
     eb_set_buffer_name(b, bufname); /* ensure that the name is unique */
     if (shell_flags & SF_COLOR) {
         eb_create_style_buffer(b, BF_STYLE_COMP);
@@ -3276,11 +3343,6 @@ static void do_shell_newline(EditState *e)
     struct timespec ts;
 
     if (e->interactive) {
-        ShellState *s = shell_get_state(e, 1);
-
-        if (s) {
-            shell_get_curpath(e->b, e->offset, s->curpath, sizeof(s->curpath));
-        }
         shell_write_char(e, '\r');
         /* give the process a chance to handle the input */
         ts.tv_sec = 0;
@@ -3553,66 +3615,11 @@ static void do_shell_toggle_input(EditState *e)
     }
 }
 
-/* get current directory from prompt on current line */
-/* XXX: should extend behavior to handle more subtile cases */
-static char *shell_get_curpath(EditBuffer *b, int offset,
-                               char *buf, int buf_size)
-{
-    char line[1024];
-    char curpath[MAX_FILENAME_SIZE];
-    int start, stop0, stop, i, len, offset1;
-
-    offset = eb_goto_bol(b, offset);
-again:
-    len = eb_fgets(b, line, sizeof(line), offset, &offset1);
-    line[len] = '\0';   /* strip the trailing newline if any */
-
-    start = stop = stop0 = 0;
-    for (i = 0; i < len;) {
-        char c = line[i++];
-        if (c == '#' || c == '$' || c == '>') {
-            stop = stop0;
-            break;
-        }
-        if (c == ':' && line[i] != '\\'
-        &&  !(line[i] == '/' && line[i + 1] == '/')
-        &&  !(line[i] == '/' && line[i + 1] == '*'))
-            start = i;
-        if (c == ' ') {
-            if (!start || start == i - 1)
-                start = i;
-        } else {
-            stop0 = i;
-        }
-    }
-    if (stop > start) {
-        line[stop] = '\0';
-        /* XXX: should use a lower level function to avoid potential recursion */
-        canonicalize_absolute_path(NULL, curpath, sizeof curpath, line + start);
-        if (is_directory(curpath)) {
-            append_slash(curpath, sizeof curpath);
-            return pstrcpy(buf, buf_size, curpath);
-        }
-    }
-    /* XXX: limit backlook? */
-    if (offset > 0) {
-        offset = eb_prev_line(b, offset);
-        goto again;
-    }
-    return NULL;
-}
-
 static char *shell_get_default_path(EditBuffer *b, int offset,
                                     char *buf, int buf_size)
 {
-#if 0
-    ShellState *s = qe_get_buffer_mode_data(b, &shell_mode, NULL);
-
-    if (s && (s->curpath[0] || shell_get_curpath(b, offset, s->curpath, sizeof(s->curpath)))) {
-        return pstrcpy(buf, buf_size, s->curpath);
-    }
-#endif
-    return shell_get_curpath(b, offset, buf, buf_size);
+    QEProperty *p = eb_find_property(b, 0, offset, QE_PROP_CWD);
+    return pstrcpy(buf, buf_size, p ? p->data : b->filename);
 }
 
 static void shell_kill_process_confirm_cb(void *opaque, char *reply, CompletionDef *completion)

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2448,6 +2448,7 @@ static void shell_read_cb(void *opaque)
     EditBuffer *b;
     unsigned char buf[16 * 1024];
     int len, i, save_readonly;
+    int prev_offset;
 
     if (!s || s->base.mode != &shell_mode)
         return;
@@ -2467,6 +2468,7 @@ static void shell_read_cb(void *opaque)
     /* Suspend BF_READONLY flag to allow shell output to readonly buffer */
     save_readonly = b->flags & BF_READONLY;
     b->flags &= ~BF_READONLY;
+    prev_offset = b->offset = b->total_size;
     b->last_log = 0;
 
     if (s->shell_flags & SF_COLOR) {
@@ -2514,8 +2516,10 @@ static void shell_read_cb(void *opaque)
     }
 
     EditState *e = qs->active_window;
-    if (e->b == b && !e->interactive && qs->last_cmd_func == (CmdFunc)do_eof)
-        e->offset = b->total_size;
+    if (e->b == b) {
+        if ((e->offset == prev_offset) || (qs->last_cmd_func == (CmdFunc)do_eof))
+            e->offset = b->total_size;
+    }
 
     /* now we do some refresh (should just invalidate?) */
     qe_display(qs);
@@ -2620,30 +2624,29 @@ static void shell_close(ShellState *s)
                      s->caption, strsignal(WTERMSIG(status)));
         }
         if (*buf != '\0') {
-            int save_readonly = s->b->flags & BF_READONLY;
+            int save_readonly = b->flags & BF_READONLY;
             int prev_offset;
 
             e = qs->active_window;
-
             if (!(s->shell_flags & SF_INTERACTIVE))
                 put_status(e, "%s", buf);
 
             /* Flush output to buffer, bypassing readonly flag */
-            s->b->flags &= ~BF_READONLY;
+            b->flags &= ~BF_READONLY;
 
             prev_offset = b->offset = b->total_size;
             eb_printf(b, "\n%s at %s", buf, time_str);
 
             if (e->b == b) {
-                if ((!e->interactive && qs->last_cmd_func == (CmdFunc)do_eof)
-                ||  (e->offset == prev_offset)) {
+                if (e->interactive || (e->offset == prev_offset)
+                || (qs->last_cmd_func == (CmdFunc)do_eof)) {
                     e->offset = b->total_size;
                 }
             }
 
             if (save_readonly) {
-                s->b->modified = 0;
-                s->b->flags |= BF_READONLY;
+                b->modified = 0;
+                b->flags |= BF_READONLY;
             }
         }
     }
@@ -2655,7 +2658,7 @@ static void shell_close(ShellState *s)
     }
 
     for (e = qs->first_window; e != NULL; e = e->next_window) {
-        if (e->b == s->b) {
+        if (e->b == b) {
             if (s->shell_flags & SF_AUTO_CODING)
                 do_set_auto_coding(e, 0);
             if (s->shell_flags & SF_AUTO_MODE)

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -3753,15 +3753,26 @@ static void do_compile(EditState *s, const char *cmd)
 static void do_next_error(EditState *s, int arg, int dir)
 {
     QEmacsState *qs = s->qs;
-    EditState *e;
+    EditState *e, *e_next;
     EditBuffer *b;
     int offset, found_offset;
     char filename[MAX_FILENAME_SIZE];
     char fullpath[MAX_FILENAME_SIZE];
     buf_t fnamebuf, *fname;
-    int line_num, col_num, len;
+    int line_num, col_num;
     char32_t c;
-    char error_message[128];
+    struct stat sb;
+
+    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+        put_error(s, "%s", "Please start command in a normal window");
+        return;
+    }
+
+    if (s->flags & WF_POPLEFT) {
+        /* avoid messing with the dired pane */
+        s = find_window(s, KEY_RIGHT, s);
+        qs->active_window = s;
+    }
 
     if (arg != NO_ARG) {
         /* called with a prefix: set the error source to the current buffer */
@@ -3851,8 +3862,6 @@ static void do_next_error(EditState *s, int arg, int dir)
                 goto next_line;
             c = eb_nextc(b, offset, &offset);
         }
-        len = eb_fgets(b, error_message, sizeof(error_message), offset, &offset);
-        error_message[len] = '\0';   /* strip the trailing newline if any */
         if (line_num >= 1) {
             if (line_num != error_state.line_num
             ||  col_num != error_state.col_num
@@ -3867,19 +3876,45 @@ static void do_next_error(EditState *s, int arg, int dir)
         offset = found_offset;
     }
     error_state.offset = found_offset;
-    /* update offsets */
-    for (e = qs->first_window; e != NULL; e = e->next_window) {
-        if (e->b == b) {
-            e->offset = error_state.offset;
-        }
+
+    for (e = qs->first_window; e != NULL; e = e_next) {
+        e_next = e->next_window;
+        if (e->flags & (WF_POPUP | WF_POPLEFT))
+            edit_close(&e);
     }
 
-    /* CG: Should remove popups, sidepanes, helppanes... */
+    /* check file and go to the error */
+    if (stat(fullpath, &sb) < 0) {
+        // XXX: should prompt for fullpath as a fallback
+        put_error(qs->active_window, "Cannot find error in '%s': %s",
+                  fullpath, strerror(errno));
+    } else
+    if (!S_ISREG(sb.st_mode)) {
+        put_error(qs->active_window, "Cannot find error in '%s': %s",
+                  fullpath, "not a regular file");
+    } else {
+        /* find a window showing the error source
+           buffer, split a new one if none is found  */
+        if ((e = eb_find_window(b, NULL)) == NULL)
+            e = shell_target_window(s, b);
 
-    /* go to the error */
-    /* XXX: should check for file existence */
-    do_find_file(s, fullpath, 0);
-    do_goto_line(qs->active_window, line_num, col_num);
+        /* if there is only one window and is showing the error
+           source buffer then split a new window to find the file in */
+        if (e == s && (s = get_next_window(s, WF_MINIBUF | WF_HIDDEN, 0)) == NULL)
+            s = shell_target_window(e, b);
+
+        /* update error window */
+        e->interactive = 0;
+        e->offset_top = e->offset = error_state.offset;
+        if (qs->shell_buffer_read_only)
+            b->flags |= BF_READONLY;
+
+        /* set and update active window */
+        qs->active_window = s;
+        do_find_file(s, fullpath, 0);
+        do_goto_line(s, line_num, col_num);
+        do_center_cursor(s, 1);
+    }
 
 #if 0  // conflicts with muscle memory (chqrlie)
     if (!qs->first_transient_key) {
@@ -3887,7 +3922,6 @@ static void do_next_error(EditState *s, int arg, int dir)
         qe_register_transient_binding(qs, "previous-error", "M-p");
     }
 #endif
-    put_status(s, "=> %s", error_message);
 }
 
 static int match_digits(const char32_t *buf, int n, char32_t sep) {

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -174,6 +174,54 @@ If the RENAMEFILE argument is not null and starts with 'y', an
 attempt is made to rename the old visited file to the new name
 FILENAME.
 
+### `shell(int argval)`
+
+Start a shell buffer or move to the last shell buffer used.
+If a argval is provided and equal to one, the command attempts
+to switch to an existing, active shell buffer. If the process has
+already terminated, it will restart the shell in the original directory.
+If no shell buffer exists, or argval is not equal to one, it starts a
+new shell in the default directory of the current window.
+
+### Current Working Directory Synchronization
+
+QEmacs supports tracking the current working directory of the shell
+through OSC 7 escape sequences. This allows commands such as
+`next-error` to resolve relative file names against the directory
+reported by the shell.
+
+To enable this feature, add an OSC 7 hook to your shell's startup
+file. The examples below emit an OSC 7 sequence before each prompt
+when running inside QEmacs:
+
+**Bash:**
+```bash
+if [ "$TERM_PROGRAM" = "qemacs" ]; then
+    export PROMPT_COMMAND='echo -ne "\e]7;file://${PWD}\a"'
+fi
+```
+**Zsh:**
+```zsh
+if [ "$TERM_PROGRAM" = "qemacs" ]; then
+    function precmd() {
+        builtin print -Pn "\e]7;file://${PWD}\a"
+    }
+fi
+```
+**Fish:**
+```fish
+if test "$TERM_PROGRAM" = "qemacs"
+    function sync_qemacs_shell --on-event=fish_prompt
+        printf "\e]7;file://$PWD\a"
+    end
+end
+```
+Other shells can be configured similarly by emitting:
+`ESC ] 7 ; file://cwd BEL`
+
+whenever the prompt is displayed or the current working
+directory changes.
+
 ### `start-kbd-macro()`
 
 Record subsequent keyboard input, defining a keyboard macro.

--- a/qe.c
+++ b/qe.c
@@ -4849,7 +4849,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
         line++;
         if (line < s->colorize_nb_valid_lines)
             s->colorize_nb_valid_lines = line;
-        eb_delete_properties(b, s->colorize_max_valid_offset, INT_MAX);
+        eb_delete_properties(b, s->colorize_max_valid_offset, INT_MAX, 0);
         s->colorize_max_valid_offset = INT_MAX;
     }
 
@@ -8605,7 +8605,8 @@ void do_kill_buffer(EditState *s, const char *bufname, int force)
                             kill_process_confirm_cb, md);
         } else {
             /* if modified and associated to a filename, then ask */
-            if (!force && b->modified && b->filename[0] != '\0') {
+            if (!force && !(b->flags & (BF_DIRED | BF_SHELL))
+            && b->modified && b->filename[0] != '\0') {
                 qe_stop_macro(qs);
                 snprintf(buf, sizeof(buf),
                          "Buffer %s modified; kill anyway? (yes or no) ", bufname);
@@ -9578,7 +9579,8 @@ static void quit_examine_buffers(QuitState *is)
 
     while (is->b != NULL) {
         b = is->b;
-        if (!(b->flags & BF_SYSTEM) && b->filename[0] != '\0' && b->modified) {
+        if (!(b->flags & (BF_SYSTEM | BF_DIRED | BF_SHELL))
+        && b->filename[0] != '\0' && b->modified) {
             switch (is->state) {
             case QS_ASK:
                 /* XXX: display cursor */

--- a/qe.h
+++ b/qe.h
@@ -643,7 +643,9 @@ extern EditBufferDataType raw_data_type;
 struct QEProperty {
     int offset;
 #define QE_PROP_FREE  1
+#define QE_PROP_SKIP  4
 #define QE_PROP_TAG   3
+#define QE_PROP_CWD   13
     int type;
     void *data;
     QEProperty *next;
@@ -652,7 +654,7 @@ struct QEProperty {
 void eb_add_property(EditBuffer *b, int offset, int type, void *data);
 QEProperty *eb_find_property(EditBuffer *b, int offset, int offset2, int type);
 void eb_add_tag(EditBuffer *b, int offset, const char *s);
-void eb_delete_properties(EditBuffer *b, int offset, int offset2);
+void eb_delete_properties(EditBuffer *b, int offset, int offset2, int force);
 
 /* qe module handling */
 

--- a/qestyles.h
+++ b/qestyles.h
@@ -25,6 +25,10 @@
               QERGB(0x00, 0x00, 0x00), QERGB(0xf8, 0xd8, 0xb0), 0, 0)
     STYLE_DEF(QE_STYLE_SELECTION, "selection", /* white on blue */
               QERGB(0xff, 0xff, 0xff), QERGB(0x00, 0x00, 0xff), 0, 0)
+    STYLE_DEF(QE_STYLE_ERROR_LOCATION, "error-location",
+              QERGB(0xff, 0xff, 0xff), COLOR_TRANSPARENT,
+              QE_FONT_STYLE_BOLD, 0)
+
 
     /* Generic syntax coloring styles */
     STYLE_DEF(QE_STYLE_COMMENT, "comment", /* #f84400 */


### PR DESCRIPTION
improve colors and styles

* add error-location style and colorize error locations.

Add documentation for OSC 7 support

shell: improve current directory handling

* track the shell's current working directory using OSC 7.
* add `QE_PROP_CWD` buffer property, associate it with shell's cwd.

shell: improve next-error

* remove popups, sidepanes, helppanes.
* verify file existence before opening.
* refine error/source windows:
    * find window showing the error source buffer,
      split a new one if none are found.
    * if current window is showing error source buffer,
      find file in next window, split a new one if none are found.
    * center cursor after going to error.
* show error line on window's first line.
* center cursor after going to error.


shell: follow caption message on interactive shell

* remove unnecessary check.
* minor cosmetics.

shell: avoid silent exit for commands starting in popup/minibuf.