### PR TITLE
Colorization: improve colorization of diff and process output

### DIFF
--- a/color.c
+++ b/color.c
@@ -1111,6 +1111,12 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
 {
     int i, cmin, dmin, d;
 
+    if (color == COLOR_TRANSPARENT) {
+        if (dist)
+            *dist = 0;
+        return 0x800;
+    }
+
     color &= 0xFFFFFF;  /* mask off the alpha channel */
 
     if (count >= 0x1000000) {
@@ -1221,7 +1227,7 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
                 }
                 if (dmin) {
                     for (i = 0; i < nb_custom_colors; i++) {
-                        if (custom_colors[i] == color) {
+                        if (custom_colors[i] == (color | 0xFF000000)) {
                             cmin = i + 0x800 + (i & 256) * 6;
                             dmin = 0;
                             break;
@@ -1258,7 +1264,7 @@ QEColor qe_unmap_color(int color, int count) {
         }
         if ((color & 0x700) == 0) {
             /* 0x800 indicates a custom palette entry */
-            return custom_colors[color & 255] | 0xFF000000;
+            return custom_colors[color & 255];
         }
         if ((color & 0xf00) < 0xf00) {
             /* 14 256-level color ramps */
@@ -1271,7 +1277,7 @@ QEColor qe_unmap_color(int color, int count) {
             return QERGB(r, g, b);
         } else {
             /* 0xf00 indicates the second half of the custom palette */
-            return custom_colors[color - 0xe00] | 0xFF000000;
+            return custom_colors[color - 0xe00];
         }
     }
     /* explicit RGB color with full alpha channel */
@@ -1284,7 +1290,7 @@ static int add_custom_color(QEColor color) {
         qe_map_color(color, xterm_colors, 8192, &dist);
         if (dist && nb_custom_colors < countof(custom_colors)) {
             index = nb_custom_colors++;
-            custom_colors[index] = color & 0x00FFFFFF;
+            custom_colors[index] = color | 0xFF000000;
         }
     }
     return index;
@@ -1292,6 +1298,7 @@ static int add_custom_color(QEColor color) {
 
 int colors_init(void) {
     int i;
+    custom_colors[nb_custom_colors++] = COLOR_TRANSPARENT;
     for (i = 0; i < nb_default_colors; i++) {
         /* register colors in the custom palette (if not found) */
         add_custom_color(default_colors[i].color);

--- a/extras.c
+++ b/extras.c
@@ -1663,17 +1663,17 @@ static int str_get_word7(char *buf, int size, const char *p, const char **pp)
     return len;
 }
 
-int qe_term_get_style(const char *str, QETermStyle *style)
+int qe_term_get_style(QETermStyle *style, const char *str)
 {
     char buf[128];
     QEColor fg_color, bg_color;
     unsigned int fg, bg, attr;
-    int len;
     const char *p = str;
 
     attr = 0;
-    for (;;) {
-        len = str_get_word7(buf, sizeof(buf), p, &p);
+    fg_color = COLOR_TRANSPARENT;
+    bg_color = COLOR_TRANSPARENT;
+    while (str_get_word7(buf, sizeof(buf), p, &p)) {
 
         if (strfind("bold|strong", buf)) {
             attr |= QE_TERM_BOLD;
@@ -1691,19 +1691,15 @@ int qe_term_get_style(const char *str, QETermStyle *style)
             attr |= QE_TERM_BLINK;
             continue;
         }
-        break;
-    }
-    fg_color = QERGB(0xbb, 0xbb, 0xbb);
-    bg_color = QERGB(0x00, 0x00, 0x00);
-    if (len > 0) {
-        if (css_get_color(&fg_color, buf))
-            return 1;
-        len = str_get_word7(buf, sizeof(buf), p, &p);
+        if (!css_get_color(&fg_color, buf)) {
+            continue;
+        }
         if (strfind("/|on", buf)) {
             str_get_word7(buf, sizeof(buf), p, &p);
-            if (css_get_color(&bg_color, buf))
-                return 2;
+            if (!css_get_color(&bg_color, buf))
+                continue;
         }
+        return 1;
     }
     fg = qe_map_color(fg_color, xterm_colors, QE_TERM_FG_COLORS, NULL);
     bg = qe_map_color(bg_color, xterm_colors, QE_TERM_BG_COLORS, NULL);
@@ -1712,42 +1708,87 @@ int qe_term_get_style(const char *str, QETermStyle *style)
     return 0;
 }
 
-static int qe_term_get_style_string(char *dest, size_t size, QEStyleDef *stp)
+int qe_styledef_string(char *dest, size_t size, const QEStyleDef *stp)
 {
     buf_t out[1];
     char buf[16];
     const char *p;
 
     buf_init(out, dest, size);
-#if 0
-    if (stp->attr & QE_TERM_BOLD)
-        buf_printf(out, " %s", "bold");
-    if (stp->attr & QE_TERM_ITALIC)
-        buf_printf(out, " %s", "italic");
-    if (stp->attr & QE_TERM_UNDERLINE)
-        buf_printf(out, " %s", "underlined");
-    if (stp->attr & QE_TERM_BLINK)
-        buf_printf(out, " %s", "blinking");
-#endif
+    if (stp->font_style & QE_FONT_STYLE_BOLD)
+        buf_put_word(out, "bold");
+    if (stp->font_style & QE_FONT_STYLE_ITALIC)
+        buf_put_word(out, "italic");
+    if (stp->font_style & QE_FONT_STYLE_UNDERLINE)
+        buf_put_word(out, "underlined");
+    if (stp->font_style & QE_FONT_STYLE_BLINK)
+        buf_put_word(out, "blinking");
     p = css_get_color_name(buf, sizeof buf, stp->fg_color, TRUE);
-    buf_printf(out, " %s", p);
+    buf_put_word(out, p);
     if (stp->bg_color != COLOR_TRANSPARENT) {
         p = css_get_color_name(buf, sizeof buf, stp->bg_color, TRUE);
-        buf_printf(out, " on %s", p);
+        buf_put_word(out, "on");
+        buf_put_word(out, p);
     }
     switch (stp->font_style) {
     case QE_FONT_FAMILY_SERIF:
-        buf_printf(out, " %s", "times");
+        buf_put_word(out, "times");
         break;
     case QE_FONT_FAMILY_SANS:
-        buf_printf(out, " %s", "arial");
+        buf_put_word(out, "arial");
         break;
     case QE_FONT_FAMILY_FIXED:
-        buf_printf(out, " %s", "fixed");
+        buf_put_word(out, "fixed");
         break;
     }
-    if (stp->font_size)
-        buf_printf(out, " %dpt", stp->font_size);
+    if (stp->font_size) {
+        snprintf(buf, sizeof(buf), "%dpt", stp->font_size);
+        buf_put_word(out, buf);
+    }
+    return out->len;
+}
+
+int qe_term_style_string(char *dest, size_t size, QETermStyle style)
+{
+    buf_t out[1];
+    char buf[16];
+    const char *p;
+
+    buf_init(out, dest, size);
+
+    if (style & QE_TERM_COMPOSITE) {
+        QEColor fg_color, bg_color;
+        int fg, bg;
+        if (style & QE_TERM_BOLD)
+            buf_put_word(out, "bold");
+        if (style & QE_TERM_ITALIC)
+            buf_put_word(out, "italic");
+        if (style & QE_TERM_UNDERLINE)
+            buf_put_word(out, "underlined");
+        if (style & QE_TERM_BLINK)
+            buf_put_word(out, "blinking");
+        // FIXME: should support default foreground
+        fg = QE_TERM_GET_FG(style);
+        fg_color = qe_unmap_color(fg, QE_TERM_FG_COLORS);
+        p = css_get_color_name(buf, sizeof buf, fg_color, TRUE);
+        buf_put_word(out, p);
+        // FIXME: should support transparent background
+        bg = QE_TERM_GET_BG(style);
+        bg_color = qe_unmap_color(bg, QE_TERM_BG_COLORS);
+        p = css_get_color_name(buf, sizeof buf, bg_color, TRUE);
+        buf_put_word(out, "on");
+        buf_put_word(out, p);
+    } else {
+        if (style < QE_STYLE_NUM && qe_styles[style].name) {
+            buf_put_word(out, qe_styles[style].name);
+        } else {
+            buf_printf(out, "0x%x", style);
+        }
+    }
+    if (style & QE_STYLE_SEL) {
+        buf_put_word(out, "selection");
+    }
+
     return out->len;
 }
 
@@ -1797,7 +1838,7 @@ static void do_set_region_color(EditState *s, const char *str)
     /* deactivate region hilite */
     s->region_style = 0;
 
-    if (qe_term_get_style(str, &style)) {
+    if (qe_term_get_style(&style, str)) {
         put_error(s, "Invalid color '%s'", str);
         return;
     }
@@ -2778,7 +2819,7 @@ static int eb_print_style(EditBuffer *b, const char *name, int style) {
 
     *buf = '\0';
     if (stp) {
-        qe_term_get_style_string(buf, sizeof buf, stp);
+        qe_styledef_string(buf, sizeof buf, stp);
     }
     len += eb_printf(b, " %-40s", buf);
     return len;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -3895,6 +3895,37 @@ static int match_string(const char32_t *buf, int n, const char *str) {
     return (str[i] == '\0') ? i : 0;
 }
 
+// Try and match diff marks. Accept patch style and default diff style
+static int match_diff(const char32_t *buf, int n) {
+    int i = 0;
+
+    // Accept lines starting with @@ (patch style location lines)
+    if (n > 2 && buf[0] == '@' && buf[1] == '@')
+        return 1;
+
+    // Accept --- (diff style block separators)
+    if (n == 3 && buf[0] == '-' && buf[1] == '-' && buf[2] == '-')
+        return 1;
+
+    // Accept lines matching [0-9]+[adc][0-9]+(,[0-9]+)? (diff style location lines)
+    if (!qe_isdigit(buf[i])) return 0;
+    while (qe_isdigit(buf[++i]))
+        continue;
+    if (i == n || (buf[i] != 'a' && buf[i] != 'd' && buf[i] != 'c'))
+        return 0;
+    if (!qe_isdigit(buf[++i])) return 0;
+    while (qe_isdigit(buf[++i]))
+        continue;
+    if (i == n) return 1;
+    if (buf[i] != ',') return 0;
+    if (!qe_isdigit(buf[++i])) return 0;
+    while (qe_isdigit(buf[++i]))
+        continue;
+    if (i == n) return 1;
+
+    return 0;
+}
+
 static int shell_grab_filename(const char32_t *buf, int n,
                                char *dest, int size, int filter)
 {
@@ -3960,13 +3991,22 @@ void shell_colorize_line(QEColorizeContext *cp,
     /* detect match lines for known languages and colorize accordingly */
     char filename[MAX_FILENAME_SIZE];
     ModeDef *m;
-    int i = 0, start = 0, style = 0;
+    int i = 0, start = 0;
 
     if (qe_isspace(str[0])) {
         if (cp->colorize_state & STATE_SHELL_SKIP)
             start = 1;
     } else {
         /* Detect patches and colorize according to filename */
+        if ((cp->colorize_state & STATE_SHELL_KEEP) && match_diff(str, n)) {  /* patch/diff location lines */
+            /* reset current multiline state */
+            cp->colorize_state &= STATE_SHELL_MASK;
+            if (cp->colorize_state & STATE_SHELL_MODE) {
+                cp->line_style = QE_STYLE_DIFF_MARK;
+                cp->combine_stop = 0;
+            }
+            return;
+        } else
         if (str[0] == '+' || str[0] == '-') {
             if (match_string(str, n, "+++ ") || match_string(str, n, "--- ")) {
                 /* extract filename, strip some known prefixes and suffixes */
@@ -3987,13 +4027,17 @@ void shell_colorize_line(QEColorizeContext *cp,
                 shell_grab_filename(p, q - p, filename, countof(filename), FALSE);
                 cp->colorize_state = qe_shell_find_mode(cp->s->qs, filename);
                 cp->colorize_state |= STATE_SHELL_SKIP | STATE_SHELL_KEEP;
-                SET_STYLE(sbuf, 0, n, QE_STYLE_DIFF_HEAD);
+                cp->line_style = QE_STYLE_DIFF_HEAD;
                 cp->combine_stop = 0;
                 return;
             } else {
-                // XXX: combine colorized code with background color
-                style = (str[0] == '-') ? QE_STYLE_DIFF_OLD : QE_STYLE_DIFF_NEW;
-                start = 1;
+                if (cp->colorize_state & STATE_SHELL_SKIP) {
+                    if (str[0] == '-')
+                        cp->line_style = QE_STYLE_DIFF_OLD;
+                    else
+                        cp->line_style = QE_STYLE_DIFF_NEW;
+                    start = 1;
+                }
             }
         } else
         if (str[0] == '<' || str[0] == '>') {
@@ -4003,15 +4047,7 @@ void shell_colorize_line(QEColorizeContext *cp,
                 return;
         } else
         if (match_string(str, n, "diff ") || match_string(str, n, "Only in ")) {
-            return;
-        } else
-        if (match_string(str, n, "@@")) {  /* patch/diff location lines */
-            /* reset current multiline state */
-            cp->colorize_state &= STATE_SHELL_MASK;
-            if (cp->colorize_state & STATE_SHELL_MODE) {
-                SET_STYLE(sbuf, 0, n, QE_STYLE_DIFF_MARK);
-                cp->combine_stop = 0;
-            }
+            // XXX if in colored output, should use cp->line_style = QE_STYLE_DIFF_OLD
             return;
         } else
         if (match_string(str, n, "==> ") && match_string(str + n - 4, 4, " <==")) {
@@ -4019,35 +4055,42 @@ void shell_colorize_line(QEColorizeContext *cp,
             shell_grab_filename(str + 4, n - 8, filename, countof(filename), FALSE);
             cp->colorize_state = qe_shell_find_mode(cp->s->qs, filename);
             cp->colorize_state |= STATE_SHELL_KEEP;
-            SET_STYLE(sbuf, 0, n, QE_STYLE_DIFF_HEAD);
+            cp->line_style = QE_STYLE_DIFF_HEAD;
             cp->combine_stop = 0;
             return;
         } else {
             /* Detect compiler messages and colorize according to filename */
             while (i < n) {
-                int w;
+                int w = 0;
                 char32_t c = str[i];
                 if (qe_isspace(c)) {
                     i++;
                     if (match_string(str + i, n - i, "> ")
                     ||  match_string(str + i, n - i, "$ ")) {
+                        /* Detect invocations of file commands */
                         static const char * const commands[] = {
                             "diff ", "head ", "tail ", "cat ", NULL
                         };
                         int k;
-                        /* Detect invocations of diff, grep, d... */
                         i += 2;
-                        /* This looks like a prompt: reset the current mode */
-                        //cp->colorize_state = 0;
                         for (k = 0; commands[k]; k++) {
-                            if ((w = match_string(str + i, n - i, commands[k])) != 0) {
-                                i += w;
-                                shell_grab_filename(str + i, n - i, filename, countof(filename), FALSE);
+                            if ((w = match_string(str + i, n - i, commands[k])) != 0)
+                                break;
+                        }
+                        if (w) {
+                            for (i += w; i < n; i++) {
+                                if (qe_isspace(str[i]))
+                                    continue;
+                                i += shell_grab_filename(str + i, n - i, filename, countof(filename), FALSE);
+                                if (*filename == '-')
+                                    continue;
                                 cp->colorize_state = qe_shell_find_mode(cp->s->qs, filename);
-                                cp->colorize_state |= STATE_SHELL_KEEP;
-                                start = n;
-                                return;
+                                if (cp->colorize_state) {
+                                    cp->colorize_state |= STATE_SHELL_KEEP;
+                                    return;
+                                }
                             }
+                            return;
                         }
                     }
                 } else {
@@ -4058,7 +4101,8 @@ void shell_colorize_line(QEColorizeContext *cp,
                         if (p != NULL && p > filename && p[-1] != ' ') {
                             /* This looks like a prompt: reset the current mode */
                             cp->colorize_state = 0;
-                            return;
+                            i += w;
+                            continue;
                         }
                     }
                     if (w <= 0) {
@@ -4100,27 +4144,20 @@ void shell_colorize_line(QEColorizeContext *cp,
     }
     if ((cp->colorize_state & STATE_SHELL_MODE)
     &&  (m = mode_cache[cp->colorize_state & STATE_SHELL_MODE]) != NULL) {
-        if (style) {
-            SET_STYLE(sbuf, 0, n, style);
-            cp->combine_stop = 0;
+        int save_state = cp->colorize_state;
+        cp->colorize_state >>= STATE_SHELL_SHIFT;
+        cp->partial_file++;
+        cp->mode_flags = m->flags;
+        cp_colorize_line(cp, str, start, n, sbuf, m);
+        cp->partial_file--;
+        if (save_state & STATE_SHELL_KEEP) {
+            cp->colorize_state <<= STATE_SHELL_SHIFT;
+            cp->colorize_state |= save_state & STATE_SHELL_MASK;
         } else {
-            int save_state = cp->colorize_state;
-            cp->colorize_state >>= STATE_SHELL_SHIFT;
-            cp->partial_file++;
-            cp_colorize_line(cp, str, start, n, sbuf, m);
-            cp->partial_file--;
-            if (save_state & STATE_SHELL_KEEP) {
-                cp->colorize_state <<= STATE_SHELL_SHIFT;
-                cp->colorize_state |= save_state & STATE_SHELL_MASK;
-            } else {
-                cp->colorize_state = 0;
-            }
-            cp->combine_stop = start;
+            cp->colorize_state = 0;
         }
-        /* Colorize trailing blanks if colorizing shell output */
-        for (i = n; i > start && qe_isblank(str[i - 1]); i--) {
-            SET_STYLE1(sbuf, i - 1, QE_STYLE_BLANK_HILITE);
-        }
+        cp->combine_stop = start;
+        cp->combine_skip = start; // restrict trailing blank colorizer
     } else {
         cp->colorize_state = 0;
     }

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -280,6 +280,17 @@ Encode a sequence of keys as a qemacs strings into a fixed length buffer
 Return the number of bytes produced in the destination array,
 not counting the null terminator.
 
+### `int buf_put_word(buf_t *bp, const char *str);`
+
+Append a word to a fixed length buffer. Insert a space
+if buffer is not empty.
+
+* argument `bp` a valid pointer to fixed length buffer
+
+* argument `str` a valid pointer to a C string
+
+Return the number of bytes actually written.
+
 ### `int buf_putc_utf8(buf_t *bp, char32_t c);`
 
 Encode a codepoint in UTF-8 at the end of a fixed length buffer.

--- a/qe.c
+++ b/qe.c
@@ -3575,6 +3575,7 @@ static void apply_style(QEStyleDef *stp, QETermStyle style)
     QEStyleDef *s;
 
     if (style & QE_TERM_COMPOSITE) {
+        QEColor fg_color, bg_color;
         int fg = QE_TERM_GET_FG(style);
         int bg = QE_TERM_GET_BG(style);
         if (style & QE_TERM_BOLD) {
@@ -3590,9 +3591,12 @@ static void apply_style(QEStyleDef *stp, QETermStyle style)
             stp->font_style |= QE_FONT_STYLE_ITALIC;
         if (style & QE_TERM_BLINK)
             stp->font_style |= QE_FONT_STYLE_BLINK;
-        // FIXME: should support transparent background
-        stp->fg_color = qe_unmap_color(fg, QE_TERM_FG_COLORS);
-        stp->bg_color = qe_unmap_color(bg, QE_TERM_BG_COLORS);
+        fg_color = qe_unmap_color(fg, QE_TERM_FG_COLORS);
+        if (fg_color != COLOR_TRANSPARENT)
+            stp->fg_color = fg_color;
+        bg_color = qe_unmap_color(bg, QE_TERM_BG_COLORS);
+        if (bg_color != COLOR_TRANSPARENT)
+            stp->bg_color = bg_color;
     } else {
         s = &qe_styles[style & QE_STYLE_NUM];
         if (s->fg_color != COLOR_TRANSPARENT)
@@ -3616,7 +3620,7 @@ static void apply_style(QEStyleDef *stp, QETermStyle style)
 void get_style(EditState *e, QEStyleDef *stp, QETermStyle style)
 {
     /* get root default style */
-    *stp = qe_styles[0];
+    *stp = qe_styles[QE_STYLE_DEFAULT];
 
     /* apply window default style */
     if (e && e->default_style != 0)
@@ -4054,7 +4058,7 @@ static void flush_line(DisplayState *ds,
     if (ds->do_disp == DISP_PRINT
     &&  ds->y + line_height >= 0
     &&  ds->y < e->ytop + e->height) {
-        QEStyleDef styledef, default_style;
+        QEStyleDef styledef;
         int no_display = 0;
 
         /* test if display needed */
@@ -4077,7 +4081,7 @@ static void flush_line(DisplayState *ds,
                 QELineShadow *ls;
                 uint64_t crc;
 
-                crc = compute_crc(fragments, sizeof(*fragments) * nb_fragments, 0);
+                crc = compute_crc(fragments, sizeof(*fragments) * nb_fragments, ds->line_style);
                 crc = compute_crc(ds->line_chars, sizeof(*ds->line_chars) * ds->line_index, crc);
                 ls = &e->line_shadow[ds->line_num];
                 if (ls->y != ds->y || ls->x != ds->x_line
@@ -4094,7 +4098,16 @@ static void flush_line(DisplayState *ds,
         }
         if (!no_display) {
             /* display */
-            get_style(e, &default_style, QE_STYLE_DEFAULT);
+            QEStyleDef default_style;
+#if 1
+            get_style(e, &default_style, ds->line_style);
+#else
+            default_style = qe_styles[QE_STYLE_DEFAULT];
+            if (e && e->default_style != 0)
+                apply_style(&default_style, e->default_style);
+            if (ds->line_style)
+                apply_style(&default_style, ds->line_style);
+#endif
             x = ds->x_start;
             y = ds->y;
 
@@ -4111,7 +4124,13 @@ static void flush_line(DisplayState *ds,
             // XXX: handle curline_style and other line styles
             for (i = 0; i < nb_fragments && x < x1; i++) {
                 frag = &fragments[i];
+#if 0
                 get_style(e, &styledef, frag->style);
+#else
+                styledef = default_style;
+                if (frag->style)
+                    apply_style(&styledef, frag->style);
+#endif
                 // XXX: should not fill if transparent
                 fill_rectangle(screen, e->xleft + x, e->ytop + y,
                                frag->width, line_height, styledef.bg_color);
@@ -4137,7 +4156,13 @@ static void flush_line(DisplayState *ds,
                 frag = &fragments[i];
                 x += frag->width;
                 if (x > 0) {
+#if 0
                     get_style(e, &styledef, frag->style);
+#else
+                    styledef = default_style;
+                    if (frag->style)
+                        apply_style(&styledef, frag->style);
+#endif
                     font = select_font(screen,
                                        styledef.font_style, styledef.font_size);
                     draw_text(screen, font,
@@ -4884,6 +4909,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
     }
     cp->combine_stop = len - bom;
     cp->cur_pos -= bom;
+    cp->mode_flags = s->colorize_mode->flags;
     cp_colorize_line(cp, cp->buf, bom, len, cp->sbuf, s->colorize_mode);
     cp->cur_pos += bom;
     /* buf[len] has char '\0' but may hold style, force buf ending */
@@ -4908,9 +4934,10 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
             offset = eb_next(b, offset);
         }
     }
-    if (!(s->colorize_mode->flags & MODEF_NO_TRAILING_BLANKS)) {
+    if (!(cp->mode_flags & MODEF_NO_TRAILING_BLANKS)) {
         /* Mark trailing blanks as errors if cursor is not at end of line */
-        for (i = len; i > 0 && qe_isblank(cp->buf[i - 1]) && i != cp->cur_pos; i--) {
+        int start = bom + cp->combine_skip;
+        for (i = len; i > start && qe_isblank(cp->buf[i - 1]) && i != cp->cur_pos; i--) {
             cp->sbuf[i - 1] = QE_STYLE_BLANK_HILITE;
         }
     }
@@ -5109,14 +5136,13 @@ int text_display_line(EditState *s, DisplayState *ds, int offset)
             if (s->offset < offset0 || offset == offset0
             ||  (offset0 == s->b->total_size && eb_peek_prevc(s->b, offset0) != '\n')) {
                 /* XXX: only if qs->active_window == s ? */
-                int i;
-                for (i = 0; i < colored_nb_chars; i++)
-                    cp->sbuf[i] = s->curline_style;
+                cp->line_style = s->curline_style;
             }
         }
     }
 #endif
 
+    ds->line_style = cp->line_style;
     bd = embeds + 1;
     char_index = 0;
     for (;;) {

--- a/qe.h
+++ b/qe.h
@@ -278,9 +278,12 @@ struct QEColorizeContext {
     u8 reallocated;
     u8 truncated;
     int combine_start, combine_stop; /* region for combine_static_colorized_line() */
+    int combine_skip;   /* initial characters to skip (diff marks) */
+    QETermStyle line_style;
+    int mode_flags;
     int cur_pos;   /* position of cursor in line or -1 if outside line */
     int buf_size;
-    char32_t  *buf;
+    char32_t *buf;
     QETermStyle *sbuf;
     char32_t buf0[COLORED_LINE_SIZE];
     QETermStyle sbuf0[COLORED_LINE_SIZE];
@@ -1312,6 +1315,7 @@ struct DisplayState {
     int eol_reached;
     EditState *edit_state;
     QETermStyle style;   /* current style for display_printf... */
+    QETermStyle line_style; /* style of the current line... */
 
 #if 0
     QEFont *font;
@@ -1886,7 +1890,9 @@ void do_show_bindings(EditState *s, const char *cmd_name);
 void do_describe_bindings(EditState *s, int argval);
 void do_apropos(EditState *s, const char *str);
 
-int qe_term_get_style(const char *str, QETermStyle *style);
+int qe_term_get_style(QETermStyle *style, const char *str);
+int qe_term_style_string(char *dest, size_t size, QETermStyle style);
+int qe_styledef_string(char *dest, size_t size, const QEStyleDef *stp);
 int color_print_entry(CompleteState *cp, EditState *s, const char *name);
 int style_print_entry(CompleteState *cp, EditState *s, const char *name);
 

--- a/qestyles.h
+++ b/qestyles.h
@@ -63,14 +63,14 @@
               QERGB(0x00, 0x00, 0x00), QERGB(0xff, 0x00, 0x00), 0, 0)
 
     /* diff/patch styles */
-    STYLE_DEF(QE_STYLE_DIFF_HEAD, "diff-head", /* bright white */
-              QERGB(0xff, 0xff, 0xff), COLOR_TRANSPARENT, 0, 0)
-    STYLE_DEF(QE_STYLE_DIFF_MARK, "diff-mark", /* grey88 on blue */
-              QERGB(0xc0, 0xc0, 0xc0), QERGB(0x00, 0x00, 0x40), 0, 0)
-    STYLE_DEF(QE_STYLE_DIFF_OLD, "diff-old", /* bright white on red */
-              QERGB(0xff, 0xff, 0xff), QERGB(0x40, 0x00, 0x00), 0, 0)
-    STYLE_DEF(QE_STYLE_DIFF_NEW, "diff-new", /* bright white on green */
-              QERGB(0xff, 0xff, 0xff), QERGB(0x00, 0x40, 0x00), 0, 0)
+    STYLE_DEF(QE_STYLE_DIFF_HEAD, "diff-head", /* bold bright white */
+              QERGB(0xff, 0xff, 0xff), COLOR_TRANSPARENT, QE_FONT_STYLE_BOLD, 0)
+    STYLE_DEF(QE_STYLE_DIFF_MARK, "diff-mark", /* bold grey88 on blue */
+              QERGB(0xc0, 0xc0, 0xc0), QERGB(0x00, 0x00, 0x40), QE_FONT_STYLE_BOLD, 0)
+    STYLE_DEF(QE_STYLE_DIFF_OLD, "diff-old", /* default on dark red */
+              COLOR_TRANSPARENT, QERGB(0x40, 0x00, 0x00), 0, 0)
+    STYLE_DEF(QE_STYLE_DIFF_NEW, "diff-new", /* default on dark green */
+              COLOR_TRANSPARENT, QERGB(0x00, 0x40, 0x00), 0, 0)
 
     /* HTML coloring styles */
     STYLE_DEF(QE_STYLE_HTML_COMMENT, "html-comment", /* #f84400 */

--- a/util.c
+++ b/util.c
@@ -2156,6 +2156,20 @@ int buf_write(buf_t *bp, const void *src, int size)
     return n;
 }
 
+int buf_put_word(buf_t *bp, const char *str)
+{
+    /*@API buf
+       Append a word to a fixed length buffer. Insert a space
+       if buffer is not empty.
+       @argument `bp` a valid pointer to fixed length buffer
+       @argument `str` a valid pointer to a C string
+       @return the number of bytes actually written.
+     */
+    int n = 0;
+    if (bp->pos) n = buf_put_byte(bp, ' ');
+    return n + buf_puts(bp, str);
+}
+
 int buf_printf(buf_t *bp, const char *fmt, ...)
 {
     /*@API buf

--- a/util.h
+++ b/util.h
@@ -673,6 +673,7 @@ static inline int buf_puts(buf_t *bp, const char *str) {
     return buf_write(bp, str, strlen(str));
 }
 
+int buf_put_word(buf_t *bp, const char *str);
 int buf_printf(buf_t *bp, const char *fmt, ...) qe__attr_printf(2,3);
 int buf_putc_utf8(buf_t *bp, char32_t c);
 

--- a/variables.c
+++ b/variables.c
@@ -197,6 +197,7 @@ QVarType qe_get_variable(EditState *s, const char *name,
 {
     const VarDef *vp;
     int num = 0;
+    QETermStyle style = 0;
     const char *str = NULL;
     const void *ptr;
     const char *endp;
@@ -264,12 +265,21 @@ QVarType qe_get_variable(EditState *s, const char *name,
             pstrcpy(buf, size, str);
         break;
     case VAR_NUMBER:
-    case VAR_STYLE:
         memcpy(&num, ptr, sizeof(num));
         if (pnum)
             *pnum = num;
         else
-            snprintf(buf, size, "%d", num);
+            snprintf(buf, size, "%d  0x%x", num, (unsigned)num);
+        break;
+    case VAR_STYLE:
+        memcpy(&style, ptr, sizeof(style));
+        if (pnum) {
+            *pnum = (int)style;
+        } else {
+            int len = snprintf(buf, size, "0x%x  (", style);
+            len += qe_term_style_string(buf + len, size - len, num);
+            snprintf(buf + len, size - len, ")");
+        }
         break;
     default:
         if (size > 0)
@@ -296,7 +306,7 @@ static QVarType qe_variable_set_value_style(EditState *s, VarDef *vp, void *ptr,
                                             const char *value, int num)
 {
     QETermStyle style = num;
-    if (value && qe_term_get_style(value, &style)) {
+    if (value && qe_term_get_style(&style, value)) {
         const char *p;
         style = strtol_c(value, &p, 0);
         if (*p)
@@ -420,10 +430,14 @@ void do_show_variable(EditState *s, const char *name)
 {
     char buf[MAX_FILENAME_SIZE];
 
-    if (qe_get_variable(s, name, buf, sizeof(buf), NULL, 1) == VAR_UNKNOWN)
+    switch (qe_get_variable(s, name, buf, sizeof(buf), NULL, 1)) {
+    case VAR_UNKNOWN:
         put_error(s, "No variable %s", name);
-    else
+        break;
+    default:
         put_status(s, "%s -> %s", name, buf);
+        break;
+    }
 }
 
 void do_set_variable(EditState *s, const char *name, const char *value)


### PR DESCRIPTION
* improve color combining code for patches: show language colors on red of green background
* improve `curline_style` handling (needs more work)
* add `QETermStyle` transparent color handling in `apply_style`
* highlight trailing blanks more generically
* transpose arguments of `qe_term_get_style()` for consistency
* add `qe_term_style_string()` and `qe_styledef_string()`
* extend style parser syntax to accept missing foreground color