### PR TITLE
Prevent infinite loop property deletion bug and refine shell command other window logic

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2776,8 +2776,10 @@ static void eb_plist_callback(EditBuffer *b, void *opaque, int edge,
     if (op == LOGOP_DELETE) {
         for (pp = &b->property_list; (p = *pp) != NULL;) {
             if (p->offset >= offset) {
-                if (p->offset == offset && (p->flags & QE_PROP_MARK))
+                if (p->offset == offset && (p->flags & QE_PROP_MARK)) {
+                    pp = &p->next;
                     continue;
+                }
                 if (p->offset < offset + size) {
                     /* property is anchored inside block: remove it */
                     if (!(p->flags & QE_PROP_KEEP)) {
@@ -2789,6 +2791,7 @@ static void eb_plist_callback(EditBuffer *b, void *opaque, int edge,
                         continue;
                     }
                     p->offset = offset;
+                    pp = &p->next;
                     continue;
                 }
                 p->offset -= size;

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -4099,14 +4099,15 @@ static void do_next_error(EditState *s, int arg, int dir)
             edit_close(&e);
     }
 
-    /* find a window showing the error source buffer,
-       split a new one if none is found  */
-    if ((e = eb_find_window(b, NULL)) == NULL && qs->shell_command_other_window) {
-        e = shell_target_window(s, b);
-
-        /* if there is only one window whoing the error source buffer
+    /* find a window showing the error source
+       buffer, split a new one if none is found */
+    e = eb_find_window(b, NULL);
+    if (qs->shell_command_other_window) {
+        if (e == NULL)
+            e = shell_target_window(s, b);
+        /* if there is only one window showing the error source buffer
            then find or split a new window to find the file in */
-        if (e == s && (s = get_next_window(s, WF_MINIBUF | WF_HIDDEN, 0)) == NULL)
+        if (e == s && !(s = get_next_window(s, WF_MINIBUF | WF_HIDDEN, 0)))
             s = shell_target_window(e, b);
     }
 


### PR DESCRIPTION
* make sure to update pointer to prevent infinite loop.
* ensure new window is split if error buffer is in the current window.
