### PR TITLE
Popup handling: add generic approach to disable commands

### DIFF
--- a/extras.c
+++ b/extras.c
@@ -3364,11 +3364,11 @@ static const CmdDef extra_commands[] = {
 
     CMD2( "compare-windows", "M-=",
           "Compare windows, optionally ignoring white space, comments and case",
-          do_compare_windows, ESi, "p")
+          do_compare_windows, ESi, "#" "p")
     CMD3( "compare-files", "C-x RET C-l",
           "Compare file and other version in parent directory",
           do_compare_files, ESsi,
-          "s{Compare file: }[file]|file|"
+          "#" "s{Compare file: }[file]|file|"
           "v", 0) /* p? */
     CMD2( "define-equivalent", "",
           "Define equivalent strings for compare-windows",

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -1969,7 +1969,7 @@ static const CmdDef dired_commands[] = {
 static const CmdDef dired_global_commands[] = {
     CMD2( "dired", "C-x C-d",
           "Display the directory window and start dired mode",
-          do_dired, ESi, "P")
+          do_dired, ESi, "#" "P")
 };
 
 #if 0
@@ -2141,12 +2141,12 @@ static int filelist_mode_init(EditState *s, EditBuffer *b, int flags)
 }
 
 static const CmdDef filelist_commands[] = {
-    CMD0( "filelist-select", "RET, LF, right",
+    CMD2( "filelist-select", "RET, LF, right",
           "Select the current entry",
-          do_other_window)
-    CMD0( "filelist-tab", "TAB",
+          do_other_window, ES, "#")
+    CMD2( "filelist-tab", "TAB",
           "Select the current entry",
-          do_other_window)
+          do_other_window, ES, "#")
     /* filelist-abort should restore previous buffer in right-window
      * or at least exit preview mode */
     CMD1( "filelist-abort", "C-g",
@@ -2157,7 +2157,7 @@ static const CmdDef filelist_commands[] = {
 static const CmdDef filelist_global_commands[] = {
     CMD2( "filelist", "",
           "Run the filelist-mode on the current region",
-          do_filelist, ESi, "p")
+          do_filelist, ESi, "#" "p")
 };
 
 static int filelist_init(QEmacsState *qs)

--- a/modes/fractal.c
+++ b/modes/fractal.c
@@ -1248,7 +1248,7 @@ static void do_mandelbrot_test(EditState *s, int argval) {
 static const CmdDef fractal_global_commands[] = {
     CMD2( "mandelbrot-test", "C-h m",
           "Explore the Mandelbrot set in fractal-mode",
-          do_mandelbrot_test, ESi, "p")
+          do_mandelbrot_test, ESi, "#" "p")
 };
 
 static int fractal_init(QEmacsState *qs)

--- a/modes/latex-mode.c
+++ b/modes/latex-mode.c
@@ -325,7 +325,7 @@ static const CmdDef latex_commands[] = {
     CMD2( "TeX-command-master", "C-c C-c",
           "Run the latex process",
           do_latex, ESs,
-          "s{Command: (default LaTeX) }[latex]|latex|")
+          "#" "s{Command: (default LaTeX) }[latex]|latex|")
 };
 
 static ModeDef latex_mode = {

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2940,10 +2940,8 @@ static void do_shell(EditState *e, int argval)
     char curpath[MAX_FILENAME_SIZE];
     EditBuffer *b = NULL;
 
-    if (e->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(e, "%s", "Please start command in a normal window");
+    if (e->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     /* Start the shell in the default directory of the current window */
     get_default_path(e->b, e->offset, curpath, sizeof curpath);
@@ -3067,10 +3065,8 @@ static void do_man(EditState *s, const char *arg)
     QEmacsState *qs = s->qs;
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(s, "%s", "Please start command in a normal window");
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     if (s->flags & WF_POPLEFT) {
         /* avoid messing with the dired pane */
@@ -3109,10 +3105,8 @@ void qe_diff_buffer_with_file(EditState *s, EditBuffer *b)
     const char *tmpdir = getenv("TMPDIR");
     int tmpdir_len;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(s, "%s", "Please start command in a normal window");
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     if (!*fname)
         return;
@@ -3178,10 +3172,8 @@ static void do_ssh(EditState *s, const char *arg)
     QEmacsState *qs = s->qs;
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(s, "%s", "Please start command in a normal window");
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     if (s->flags & WF_POPLEFT) {
         /* avoid messing with the dired pane */
@@ -3903,10 +3895,8 @@ static void do_compile(EditState *s, const char *cmd)
     const char *bufname = "*compilation*";
     EditBuffer *b;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(s, "%s", "Please start command in a normal window");
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     get_default_path(s->b, s->offset, curpath, sizeof curpath);
 
@@ -4023,10 +4013,8 @@ static void do_next_error(EditState *s, int arg, int dir)
     int offset;
     struct stat sb;
 
-    if (s->flags & (WF_POPUP | WF_MINIBUF)) {
-        put_error(s, "%s", "Please start command in a normal window");
+    if (s->flags & (WF_POPUP | WF_MINIBUF))
         return;
-    }
 
     if (s->flags & WF_POPLEFT) {
         /* avoid messing with the dired pane */
@@ -4514,7 +4502,7 @@ static const CmdDef shell_commands[] = {
 static const CmdDef shell_global_commands[] = {
     CMD2( "shell", "C-x RET RET, C-x LF LF",
           "Start a shell buffer or move to the last shell buffer used",
-          do_shell, ESi, "p")
+          do_shell, ESi, "#" "p")
     CMD2( "shell-command", "M-!",
           "Run a shell command and display a new buffer with its collected output",
           do_shell_command, ESs,
@@ -4522,32 +4510,32 @@ static const CmdDef shell_global_commands[] = {
     CMD2( "interactive-shell-command", "",
           "Run a shell command interactively and display a new buffer with its collected output",
           do_interactive_shell_command, ESs,
-          "s{Interactive shell command: }|interactive-shell-command|")
+          "#" "s{Interactive shell command: }|interactive-shell-command|")
     CMD2( "ssh", "",
           "Start a shell buffer with a new remote shell connection",
           do_ssh, ESs,
-          "s{Open connection to (host or user@host: }|ssh|")
+          "#" "s{Open connection to (host or user@host: }|ssh|")
     CMD2( "compile", "C-x C-e",
           "Run a compiler command and display a new buffer with its collected output",
           do_compile, ESs,
-          "s{Compile command: }|compile|")
+          "#" "s{Compile command: }|compile|")
     CMD2( "make", "C-x m",
           "Run make and display a new buffer with its collected output",
           do_compile, ESs,
-          "@{make}")
+          "#" "@{make}")
     CMD2( "man", "",
           "Run man for a command and display a new buffer with its collected output",
           do_man, ESs,
-          "s{Show man page for: }|man|")
+          "#" "s{Show man page for: }|man|")
     CMD3( "next-error", "C-x C-n, C-x `, M-g n, M-g M-n",
           "Move to the next error from the last shell command output",
-          do_next_error, ESii, "P" "v", +1)
+          do_next_error, ESii, "#" "P" "v", +1)
     CMD3( "previous-error", "C-x C-p, M-g p, M-g M-p",
           "Move to the previous error from the last shell command output",
-          do_next_error, ESii, "P" "v", -1)
-    CMD0( "diff-buffer-with-file", "C-c C-d, C-c =",
+          do_next_error, ESii, "#" "P" "v", -1)
+    CMD2( "diff-buffer-with-file", "C-c C-d, C-c =",
           "Show differences between the buffer in the current window and its file",
-          do_diff_buffer_with_file)
+          do_diff_buffer_with_file, ES, "#")
 };
 
 static int shell_mode_probe(ModeDef *mode, ModeProbeData *p)

--- a/qe.c
+++ b/qe.c
@@ -5567,8 +5567,9 @@ int qe_get_prototype(const CmdDef *d, char *buf, int size) {
 
     /* construct argument type list */
     r = d->spec;
-    if (*r == '*') {
-        r++;    /* buffer modification indicator */
+    /* skip buffer modification indicator and popup inhibitor */
+    while (*r == '*' || *r == '#') {
+        r++;
     }
 
     while (parse_arg(&r, &cas) > 0) {
@@ -5632,11 +5633,22 @@ void exec_command(EditState *s, const CmdDef *d, int argval, int key)
         qe_trace_bytes(qs, d->name, -1, EB_TRACE_COMMAND);
 
     argdesc = d->spec;
-    if (*argdesc == '*') {
-        argdesc++;
-        if (s->b->flags & BF_READONLY) {
-            put_error(s, "Buffer is read only");
-            return;
+    for (;;) {
+        if (*argdesc == '*') {
+            argdesc++;
+            if (s->b->flags & BF_READONLY) {
+                put_error(s, "Buffer is read only");
+                return;
+            }
+        } else
+        if (*argdesc == '#') {
+            argdesc++;
+            if (s->flags & (WF_POPUP | WF_MINIBUF)) {
+                put_error(s, "Command '%s' requires a regular window", d->name);
+                return;
+            }
+        } else {
+            break;
         }
     }
 
@@ -11523,27 +11535,27 @@ static const CmdDef basic_commands[] = {
     CMD3( "find-file", "C-x C-f",
           "Load a file into a new buffer and/or display it in the current window",
           do_find_file, ESsi,
-          "s{Find file: }[file]|file|"
+          "#" "s{Find file: }[file]|file|"
           "v", 0) /* u? */
     CMD3( "find-file-other-window", "C-x M-f",
           "Load a file into a new buffer and/or display it in a new window",
           do_find_file_other_window, ESsi,
-          "s{Find file: }[file]|file|"
+          "#" "s{Find file: }[file]|file|"
           "v", 0) /* u? */
     CMD3( "find-alternate-file", "C-x C-v",
           "Load a new file into the current buffer and/or display it in the current window",
           do_find_alternate_file, ESsi,
-          "s{Find alternate file: }[file]|file|"
+          "#" "s{Find alternate file: }[file]|file|"
           "v", 0) /* u? */
     CMD3( "find-file-noselect", "",
           "Load a file into a new buffer",
           do_find_file_noselect, ESsi,
-          "s{Find file: }[file]|file|"
+          "#" "s{Find file: }[file]|file|"
           "v", 0) /* u? */
     CMD2( "insert-file", "C-x i",
           "Insert the contents of a file at point",
           do_insert_file, ESs, "*"
-          "s{Insert file: }[file]|file|") /* u? */
+          "#" "s{Insert file: }[file]|file|") /* u? */
     CMD0( "save-buffer", "C-x C-s",
           "Save the buffer contents to the associated file if modified",
           do_save_buffer) /* u? */
@@ -11559,7 +11571,7 @@ static const CmdDef basic_commands[] = {
     CMD2( "switch-to-buffer", "C-x b",
           "Change the buffer attached to the current window",
           do_switch_to_buffer, ESs,
-          "s{Switch to buffer: }[buffer]|buffer|")
+          "#" "s{Switch to buffer: }[buffer]|buffer|")
     CMD3( "kill-buffer", "C-x k",
           "Remove a named buffer",
           do_kill_buffer, ESsi,
@@ -11567,10 +11579,10 @@ static const CmdDef basic_commands[] = {
           "v", 0)
     CMD2( "next-buffer", "C-x C-right",
           "Switch to the next buffer",
-          do_buffer_navigation, ESi, "p")
+          do_buffer_navigation, ESi, "#" "p")
     CMD2( "previous-buffer", "C-x C-left",
           "Switch to the previous buffer",
-          do_buffer_navigation, ESi, "q")
+          do_buffer_navigation, ESi, "#" "q")
     CMD0( "toggle-read-only", "C-x C-q, C-c %",
           "Toggle the read-only flag of the current buffer",
           do_toggle_read_only)
@@ -11652,7 +11664,7 @@ static const CmdDef basic_commands[] = {
     CMD2( "edit-last-kbd-macro", "C-x *, C-x C-k C-e, C-x C-k e",
           "Edit the last keyboard macro",
           do_edit_last_kbd_macro, ESs,
-          "s{Macro keys: }|macrokeys|")
+          "#" "s{Macro keys: }|macrokeys|")
     CMD2( "name-last-kbd-macro", "C-x C-k C-n, C-x C-k n",
           "Define a named command from the last keyboard macro",
           do_name_last_kbd_macro, ESs,
@@ -11660,7 +11672,7 @@ static const CmdDef basic_commands[] = {
     CMD2( "insert-kbd-macro", "C-x C-k i",
           "Insert in buffer the definition of kbd macro MACRONAME, as qescript code",
           do_insert_kbd_macro, ESs,
-          "*s{Macro name: }[command]")
+          "#" "*s{Macro name: }[command]")
     CMD2( "read-kbd-macro", "C-x C-k r",
           "Read the region as a keyboard macro definition",
           do_read_kbd_macro, ESii, "m" "d")
@@ -11710,34 +11722,34 @@ static const CmdDef basic_commands[] = {
     /*---------------- Window handling ----------------*/
 
     /* should merge these functions */
-    CMD0( "other-window", "C-x o",
+    CMD2( "other-window", "C-x o",
           "Move the focus to another window",
-          do_other_window)
-    CMD0( "next-window", "C-x n",
+          do_other_window, ES, "#")
+    CMD2( "next-window", "C-x n",
           "Move the focus to the next window",
-          do_other_window)
-    CMD0( "previous-window", "C-x p",
+          do_other_window, ES, "#")
+    CMD2( "previous-window", "C-x p",
           "Move the focus to the previous window",
-          do_previous_window)
-    CMD0( "window-swap-states", "C-x /",
+          do_previous_window, ES, "#")
+    CMD2( "window-swap-states", "C-x /",
           "Swap the states of the current and next windows",
-          do_window_swap_states)
+          do_window_swap_states, ES, "#")
 #ifndef CONFIG_TINY
     CMD1( "center-cursor", "M-C-l",
           "Center the window contents at point",
           do_center_cursor, 1)
-    CMD1( "find-window-up", "C-x up",
+    CMD3( "find-window-up", "C-x up",
           "Move the focus to the window above the current one",
-          do_find_window, KEY_UP)
-    CMD1( "find-window-down", "C-x down",
+          do_find_window, ESi, "#" "v", KEY_UP)
+    CMD3( "find-window-down", "C-x down",
           "Move the focus to the window below the current one",
-          do_find_window, KEY_DOWN)
-    CMD1( "find-window-left", "C-x left",
+          do_find_window, ESi, "#" "v", KEY_DOWN)
+    CMD3( "find-window-left", "C-x left",
           "Move the focus to the window to the left of the current one",
-          do_find_window, KEY_LEFT)
-    CMD1( "find-window-right", "C-x right",
+          do_find_window, ESi, "#" "v", KEY_LEFT)
+    CMD3( "find-window-right", "C-x right",
           "Move the focus to the window to the right of the current one",
-          do_find_window, KEY_RIGHT)
+          do_find_window, ESi, "#" "v", KEY_RIGHT)
     CMD2( "scroll-left", "M-(",
           "Shift the window contents to the left",
           do_scroll_left_right, ESi, "q")
@@ -11751,31 +11763,33 @@ static const CmdDef basic_commands[] = {
     CMD1( "delete-window", "C-x 0, CLOSE",
           "Delete the current window",
           do_delete_window, 0)
-    CMD1( "delete-other-windows", "C-x 1",
+    CMD3( "delete-other-windows", "C-x 1",
           "Delete all other windows",
-          do_delete_other_windows, 0)
-    CMD1( "delete-all-windows", "",
+          do_delete_other_windows, ESi, "#" "v", 0)
+    // XXX: should be flagged as non interactive
+    CMD3( "delete-all-windows", "",
           "Delete all windows",
-          do_delete_other_windows, 1)
-    CMD1( "hide-window", "",
+          do_delete_other_windows, ESi, "#" "v", 1)
+    CMD3( "hide-window", "",
           "Hide the current window",
-          do_hide_window, 1)
+          do_hide_window, ESi, "#" "v", 1)
     CMD0( "delete-hidden-windows", "",
           "Delete the hidden windows",
           do_delete_hidden_windows)
     CMD3( "split-window-vertically", "C-x 2",
           "Split the current window top and bottom",
-          do_split_window, ESii, "P" "v", SW_STACKED)
+          do_split_window, ESii, "#" "P" "v", SW_STACKED)
     CMD3( "split-window-horizontally", "C-x 3",
           "Split the current window side by side",
-          do_split_window, ESii, "P" "v", SW_SIDE_BY_SIDE)
-    CMD0( "toggle-full-screen", "C-c f",
+          do_split_window, ESii, "#" "P" "v", SW_SIDE_BY_SIDE)
+    CMD2( "toggle-full-screen", "C-c f",
           "Toggle full screen display (on graphics displays)",
-          do_toggle_full_screen)
+          do_toggle_full_screen, ES, "#")
     CMD0( "toggle-mode-line", "C-c m",
           "Toggle mode-line display",
           do_toggle_mode_line)
 #ifdef CONFIG_SESSION
+    // XXX: should be flagged as non interactive
     CMD2( "create-window", "",
           "Create a new window with a specified layout",
           do_create_window, ESss,
@@ -11935,19 +11949,19 @@ static const CmdDef basic_commands[] = {
     CMD2( "set-mode", "",
           "Set an editing mode",
           do_set_mode, ESs,
-          "s{Set mode: }[mode]")
+          "#" "s{Set mode: }[mode]")
     CMD1( "set-auto-coding", "",
           "",
           do_set_auto_coding, 1)
-    CMD1( "set-auto-mode", "",
+    CMD3( "set-auto-mode", "",
           "Select the best mode",
-          do_set_next_mode, 0)
+          do_set_next_mode, ESi, "#" "v", 0)
     CMD2( "set-next-mode", "M-m",
           "Select the next mode appropriate for the current buffer",
-          do_set_next_mode, ESi, "p")
+          do_set_next_mode, ESi, "#" "p")
     CMD2( "set-previous-mode", "",
           "Select the previous mode appropriate for the current buffer",
-          do_set_next_mode, ESi, "q")
+          do_set_next_mode, ESi, "#" "q")
 
     /* tab & indent */
     CMD2( "set-tab-width", "",
@@ -11971,7 +11985,7 @@ static const CmdDef basic_commands[] = {
     CMD3( "load-file-from-path", "C-c C-f",
           "Load a resource file from the QEPATH",
           do_load_file_from_path, ESsi,
-          "s{Load file from path: }[resource]|file|"
+          "#" "s{Load file from path: }[resource]|file|"
           "v", 0)
     CMD2( "load-config-file", "",
           "Load a configuration file from the QEPATH",

--- a/search.c
+++ b/search.c
@@ -880,8 +880,10 @@ void do_isearch(EditState *s, int argval, int dir) {
     QEmacsState *qs = s->qs;
 
     /* prevent search from minibuffer */
-    if (s->flags & WF_MINIBUF)
+    if (s->flags & WF_MINIBUF) {
+        dpy_sound_bell(s->screen);
         return;
+    }
 
     is = set_search_state(s, argval, dir);
     if (is != NULL) {


### PR DESCRIPTION
* add `#` at the beginning of the comand argument description to disable command when current window is a popup or the minibuf
* update command definitions