### PR TITLE
Keys: fix bug on control shift bindings

### DIFF
--- a/util.c
+++ b/util.c
@@ -1915,7 +1915,7 @@ int get_modified_key(int key, int state) {
             key = 127;
         else
             key = KEY_CONTROL(key);
-    } else
+    }
     if (state & KEY_STATE_SHIFT) {
         if (key < 32 || key == 127 || KEY_IS_SPECIAL(key))
             key = KEY_SHIFT(key);


### PR DESCRIPTION
* `get_modified_key` used to ignore `KEY_STATE_SHIFT` if `KEY_STATE_CONTROL` was also passed, preventing proper parsing of `C-S-xxx` bindings