### PR TITLE
Improve color handling

### DIFF
--- a/color.c
+++ b/color.c
@@ -2,7 +2,7 @@
  * Colors for qemacs.
  *
  * Copyright (c) 2001 Fabrice Bellard.
- * Copyright (c) 2002-2024 Charlie Gordon.
+ * Copyright (c) 2002-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -111,6 +111,7 @@ static ColorDef const default_colors[] = {
     { "white",                rgb(255,255,255) }, // #FFFFFF  hsl(0,0%,100%)
     { "yellow",               rgb(255,255,0)   }, // #FFFF00  hsl(60,100%,50%)
     { "transparent",          COLOR_TRANSPARENT },
+    { "default",              COLOR_DEFAULT },
 
     /* CSS Extended color names */
     { "alice-blue",           rgb(240,248,255) }, // #F0F8FF  hsl(208,100%,97.06%)
@@ -684,8 +685,8 @@ static ColorDef const default_colors[] = {
 };
 #define nb_default_colors  countof(default_colors)
 
-static QEColor custom_colors[512];
-static int nb_custom_colors;
+QEColor custom_colors[512];
+int nb_custom_colors;
 
 ColorDef *qe_colors = unconst(ColorDef *)default_colors;
 int nb_qe_colors = nb_default_colors;
@@ -1111,11 +1112,13 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
 {
     int i, cmin, dmin, d;
 
+#ifdef QE_TERM_TRANSPARENT
     if (color == COLOR_TRANSPARENT) {
         if (dist)
             *dist = 0;
-        return 0x800;
+        return QE_TERM_TRANSPARENT;
     }
+#endif
 
     color &= 0xFFFFFF;  /* mask off the alpha channel */
 
@@ -1226,7 +1229,7 @@ unsigned int qe_map_color(QEColor color, QEColor const *colors, int count, int *
                     dmin = d;
                 }
                 if (dmin) {
-                    for (i = 0; i < nb_custom_colors; i++) {
+                    for (i = 3; i < nb_custom_colors; i++) {
                         if (custom_colors[i] == (color | 0xFF000000)) {
                             cmin = i + 0x800 + (i & 256) * 6;
                             dmin = 0;
@@ -1296,9 +1299,12 @@ static int add_custom_color(QEColor color) {
     return index;
 }
 
-int colors_init(void) {
+int colors_init(QEColor term_fg, QEColor term_bg) {
     int i;
+    nb_custom_colors = 0;
     custom_colors[nb_custom_colors++] = COLOR_TRANSPARENT;
+    custom_colors[nb_custom_colors++] = term_fg;
+    custom_colors[nb_custom_colors++] = term_bg;
     for (i = 0; i < nb_default_colors; i++) {
         /* register colors in the custom palette (if not found) */
         add_custom_color(default_colors[i].color);

--- a/color.h
+++ b/color.h
@@ -43,6 +43,7 @@ typedef uint32_t QEColor;
 #define QEARGB(a,r,g,b)    (((unsigned int)(a) << 24) | ((r) << 16) | ((g) << 8) | (b))
 #define QERGB(r,g,b)       QEARGB(0xff, r, g, b)
 #define QERGB25(r,g,b)     QEARGB(1, r, g, b)
+#define COLOR_DEFAULT      0
 #define COLOR_TRANSPARENT  0
 #define QERGB_ALPHA(c)     (((c) >> 24) & 255)
 #define QERGB_RED(c)       (((c) >> 16) & 255)
@@ -97,6 +98,9 @@ typedef uint64_t QETermStyle;
 #define QE_TERM_BG_SHIFT    32
 #define QE_TERM_FG_BITS     25
 #define QE_TERM_FG_SHIFT    0
+#undef QE_TERM_TRANSPARENT
+#define QE_TERM_DEF_FG      7
+#define QE_TERM_DEF_BG      0
 
 #elif 1   /* 8K colors for FG and BG */
 /* 32-bit style layout:
@@ -117,6 +121,9 @@ typedef uint32_t QETermStyle;
 #define QE_TERM_BG_SHIFT    19
 #define QE_TERM_FG_BITS     13
 #define QE_TERM_FG_SHIFT    0
+#define QE_TERM_TRANSPARENT 0x800   // first custom color
+#define QE_TERM_DEF_FG      0x801
+#define QE_TERM_DEF_BG      0x802
 
 #elif 1   /* 256 colors for FG and BG */
 /* 32-bit style layout for 256-color terminals:
@@ -137,6 +144,9 @@ typedef uint32_t QETermStyle;
 #define QE_TERM_BG_SHIFT    16
 #define QE_TERM_FG_BITS     8
 #define QE_TERM_FG_SHIFT    0
+#undef QE_TERM_TRANSPARENT
+#define QE_TERM_DEF_FG      7
+#define QE_TERM_DEF_BG      0
 
 #else   /* 16 colors for FG and 16 color BG */
 /* 16-bit style layout:
@@ -157,11 +167,12 @@ typedef uint16_t QETermStyle;
 #define QE_TERM_BG_SHIFT    0
 #define QE_TERM_FG_BITS     4
 #define QE_TERM_FG_SHIFT    4
+#undef QE_TERM_TRANSPARENT
+#define QE_TERM_DEF_FG      7
+#define QE_TERM_DEF_BG      0
 
 #endif
 
-#define QE_TERM_DEF_FG      7
-#define QE_TERM_DEF_BG      0
 #define QE_TERM_BG_COLORS   (1 << QE_TERM_BG_BITS)
 #define QE_TERM_FG_COLORS   (1 << QE_TERM_FG_BITS)
 #define QE_TERM_BG_MASK     ((QETermStyle)(QE_TERM_BG_COLORS - 1) << QE_TERM_BG_SHIFT)
@@ -178,6 +189,8 @@ typedef struct ColorDef {
 } ColorDef;
 
 extern QEColor const xterm_colors[];
+extern QEColor custom_colors[512];
+extern int nb_custom_colors;
 extern ColorDef *qe_colors;
 extern int nb_qe_colors;
 
@@ -218,7 +231,7 @@ static inline int css_is_inter_rect(const CSSRect *a, const CSSRect *b) {
               a->y2 <= b->y1 || a->y1 >= b->y2));
 }
 
-int colors_init(void);
+int colors_init(QEColor term_fg, QEColor term_bg);
 
 /*---- Font definitions ----*/
 

--- a/extras.c
+++ b/extras.c
@@ -1748,7 +1748,7 @@ static int str_get_word7(char *buf, int size, const char *p, const char **pp)
     return len;
 }
 
-int qe_term_get_style(QETermStyle *style, const char *str)
+int qe_term_style_parse(QETermStyle *style, const char *str)
 {
     char buf[128];
     QEColor fg_color, bg_color;
@@ -1790,6 +1790,55 @@ int qe_term_get_style(QETermStyle *style, const char *str)
     bg = qe_map_color(bg_color, xterm_colors, QE_TERM_BG_COLORS, NULL);
 
     *style = QE_TERM_COMPOSITE | attr | QE_TERM_MAKE_COLOR(fg, bg);
+    return 0;
+}
+
+int qe_styledef_parse(QEStyleDef *stp, const char *str)
+{
+    char buf[128];
+    QEColor bg_color = COLOR_TRANSPARENT;
+    QEColor fg_color = COLOR_TRANSPARENT;
+    short font_style = 0;
+    short font_size = 12;
+    const char *p = str;
+
+    while (str_get_word7(buf, sizeof(buf), p, &p)) {
+
+        if (strfind("bold|strong", buf)) {
+            font_style |= QE_FONT_STYLE_BOLD;
+            continue;
+        }
+        if (strfind("italic|italics", buf)) {
+            font_style |= QE_FONT_STYLE_ITALIC;
+            continue;
+        }
+        if (strfind("underlined|underline", buf)) {
+            font_style |= QE_FONT_STYLE_UNDERLINE;
+            continue;
+        }
+        if (strfind("blinking|blink", buf)) {
+            font_style |= QE_FONT_STYLE_BLINK;
+            continue;
+        }
+        if (!css_get_color(&fg_color, buf)) {
+            continue;
+        }
+        if (strfind("/|on", buf)) {
+            str_get_word7(buf, sizeof(buf), p, &p);
+            if (!css_get_color(&bg_color, buf))
+                continue;
+        }
+        // XXX parse font name, type...
+        if (qe_isdigit((unsigned char)*p)) {
+            font_size = (short)strtol_c(p, &p, 10);
+            strstart(p, "pt", &p);
+        }
+        return 1;
+    }
+    stp->bg_color = bg_color;
+    stp->fg_color = fg_color;
+    stp->font_style = font_style;
+    stp->font_size = font_size;
     return 0;
 }
 
@@ -1915,6 +1964,45 @@ static void do_set_style_color(EditState *e, const char *stylestr, const char *v
     e->qs->complete_refresh = 1;
 }
 
+static void do_set_default_style(EditState *s, const char *str)
+{
+    QEStyleDef styledef;
+
+    if (qe_styledef_parse(&styledef, str)) {
+        put_error(s, "Invalid style: %s", str);
+        return;
+    }
+
+    qe_styles[QE_STYLE_DEFAULT] = styledef;
+    s->qs->complete_refresh = 1;
+}
+
+static void do_set_background_color(EditState *s, const char *str)
+{
+    QEColor bg_color;
+
+    if (css_get_color(&bg_color, str)) {
+        put_error(s, "Invalid color '%s'", str);
+        return;
+    }
+
+    qe_styles[QE_STYLE_DEFAULT].bg_color = bg_color;
+    s->qs->complete_refresh = 1;
+}
+
+static void do_set_foreground_color(EditState *s, const char *str)
+{
+    QEColor fg_color;
+
+    if (css_get_color(&fg_color, str)) {
+        put_error(s, "Invalid color '%s'", str);
+        return;
+    }
+
+    qe_styles[QE_STYLE_DEFAULT].fg_color = fg_color;
+    s->qs->complete_refresh = 1;
+}
+
 static void do_set_region_color(EditState *s, const char *str)
 {
     int offset, size;
@@ -1923,7 +2011,7 @@ static void do_set_region_color(EditState *s, const char *str)
     /* deactivate region hilite */
     s->region_style = 0;
 
-    if (qe_term_get_style(&style, str)) {
+    if (qe_term_style_parse(&style, str)) {
         put_error(s, "Invalid color '%s'", str);
         return;
     }
@@ -2261,6 +2349,7 @@ static void do_describe_window(EditState *s, int argval)
     eb_print_field(b1, "force_highlight", "%d\n", s->force_highlight);
     eb_print_field(b1, "mouse_force_highlight", "%d\n", s->mouse_force_highlight);
     eb_print_field(b1, "colorize_mode", "%s\n", s->colorize_mode ? s->colorize_mode->name : "none");
+    // XXX display style definition
     eb_print_field(b1, "default_style", "%lld\n", (long long)s->default_style);
     eb_print_field(b1, "buffer", "%s\n", s->b->name);
     if (s->last_buffer)
@@ -3638,6 +3727,18 @@ static const CmdDef extra_commands[] = {
           do_describe_prefix_bindings, ESs, "@{C-x RET}")
 
     /* XXX: should take region as argument, implicit from keyboard */
+    CMD2( "set-default-style", "",
+          "Set the definition of the default style",
+          do_set_default_style, ESs,
+          "s{Style definition: }[style]|style|")
+    CMD2( "set-background-color", "",
+          "Set the default background color for current frame",
+          do_set_background_color, ESs,
+          "s{Select color: }[.color]|color|")
+    CMD2( "set-foreground-color", "",
+          "Set the default text color for current frame",
+          do_set_foreground_color, ESs,
+          "s{Select color: }[.color]|color|")
     CMD2( "set-region-color", "C-c c",
           "Set the color for the current region",
           do_set_region_color, ESs,

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -840,7 +840,7 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
     QEmacsState *qs = b->qs;
     char buf[MAX_FILENAME_SIZE];
     DiredItem *dip, *cur_item;
-    int i, col, w, width, window_width, top_line, indent;
+    int i, col, width, window_width, top_line, indent;
     int header_lines;
     const char *fname;
 
@@ -850,9 +850,8 @@ static void dired_update_buffer(DiredState *ds, EditBuffer *b, EditState *s,
     header_lines = ds->header_lines;
     /* Try and preserve scroll position */
     if (s) {
-        w = max_int(1, get_glyph_width(s->screen, s, QE_STYLE_DEFAULT, '0'));
         window_width = s->width;
-        width = window_width / w;
+        width = window_width / s->char_width;
 
         eb_get_pos(s->b, &top_line, &col, s->offset_top);
         /* XXX: should use dip->offset and delay to rebuild phase */

--- a/modes/hex.c
+++ b/modes/hex.c
@@ -169,12 +169,7 @@ static const CmdDef hex_commands[] = {
 static int binary_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
-        int num_width;
-
-        /* get typical number width */
-        num_width = get_glyph_width(s->screen, s, QE_STYLE_DEFAULT, '0');
-
-        s->dump_width = s->screen->width / num_width;
+        s->dump_width = s->screen->width / s->char_width;
         if (s->b->flags & BF_PREVIEW)
             s->dump_width = s->dump_width * 4 / 5;
 

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -1359,12 +1359,23 @@ static inline ShellState *shell_get_state(EditState *e, int status)
 static void shell_display_hook(EditState *e)
 {
     ShellState *s;
+    QEColor bg_color, fg_color;
 
     if (e->interactive) {
         if ((s = shell_get_state(e, 0)) != NULL)
             e->offset = s->cur_offset;
         if (s->use_alternate_screen)
             e->offset_top = s->alternate_screen_top;
+    }
+    bg_color = qe_styles[QE_STYLE_SHELL].bg_color;
+    if (!bg_color) bg_color = qe_styles[QE_STYLE_DEFAULT].bg_color;
+    fg_color = qe_styles[QE_STYLE_SHELL].fg_color;
+    if (!fg_color) fg_color = qe_styles[QE_STYLE_DEFAULT].fg_color;
+
+    if (fg_color != custom_colors[1] || bg_color != custom_colors[2]) {
+        custom_colors[1] = fg_color;
+        custom_colors[2] = bg_color;
+        edit_invalidate(e, 0);
     }
 }
 

--- a/qe.c
+++ b/qe.c
@@ -38,9 +38,11 @@ typedef struct HistoryEntry {
     char name[32];
 } HistoryEntry;
 
-void print_at_byte(QEditScreen *screen,
-                   int x, int y, int width, int height,
-                   const char *str, QETermStyle style);
+enum { PB_DEFAULT = 0, PB_RIGHT = 1, PB_NO_TEXT = 4 };
+static void print_at_byte(QEditScreen *screen,
+                          int x, int y, int width, int height,
+                          const char *str, QETermStyle style1,
+                          QETermStyle style2, int flags);
 static EditBuffer *predict_switch_to_buffer(EditState *s);
 static void qe_key_process(QEmacsState *qs, int key);
 
@@ -3479,7 +3481,9 @@ void display_mode_line(EditState *s)
         if (!strequal(buf, s->modeline_shadow)) {
             print_at_byte(s->screen, s->xleft, y, s->width,
                           s->qs->mode_line_height,
-                          buf, QE_STYLE_MODE_LINE);
+                          buf, QE_STYLE_MODE_LINE,
+                          !(s->flags & (WF_ACTIVE | WF_POPUP | WF_MINIBUF)) ?
+                          QE_STYLE_MODE_LINE_INACTIVE : 0, PB_DEFAULT);
             pstrcpy(s->modeline_shadow, sizeof(s->modeline_shadow), buf);
         }
     }
@@ -3531,7 +3535,9 @@ void display_window_borders(EditState *e)
                     for (len = 0; len < 256 && e->caption[len]; len++) {
                         buf[len] = e->caption[len];
                     }
-                    get_style(e, &styledef, QE_STYLE_WINDOW_BORDER);
+                    get_style(&styledef, QE_STYLE_WINDOW_BORDER,
+                              !(e->flags & (WF_ACTIVE | WF_POPUP | WF_MINIBUF)) ?
+                              QE_STYLE_WINDOW_BORDER_INACTIVE : 0);
                     font = select_font(qs->screen,
                                        styledef.font_style, styledef.font_size);
                     text_metrics(qs->screen, font, &metrics, buf, len);
@@ -3623,14 +3629,14 @@ static void apply_style(QEStyleDef *stp, QETermStyle style)
     }
 }
 
-void get_style(EditState *e, QEStyleDef *stp, QETermStyle style)
+void get_style(QEStyleDef *stp, QETermStyle window_style, QETermStyle style)
 {
     /* get root default style */
     *stp = qe_styles[QE_STYLE_DEFAULT];
 
     /* apply window default style */
-    if (e && e->default_style != 0)
-        apply_style(stp, e->default_style);
+    if (window_style)
+        apply_style(stp, window_style);
 
     /* apply specific style */
     if (style != 0)
@@ -3926,7 +3932,15 @@ void display_init(DisplayState *ds, EditState *e, enum DisplayType do_disp,
         }
     }
     /* select default values */
-    get_style(e, &styledef, QE_STYLE_DEFAULT);
+    e->window_style = QE_STYLE_WINDOW;
+    if (!(e->flags & (WF_ACTIVE | WF_POPUP | WF_MINIBUF)))
+        e->window_style = QE_STYLE_WINDOW_INACTIVE;
+    if (e->mode && e->mode->default_style)
+        e->window_style = e->mode->default_style;
+    if (e->default_style)
+        e->window_style = e->default_style;
+    ds->window_style = e->window_style;
+    get_style(&styledef, ds->window_style, 0);
     font = select_font(e->screen, styledef.font_style, styledef.font_size);
     ds->default_line_height = font->ascent + font->descent;
     ds->space_width = glyph_width(e->screen, font, ' ');
@@ -4085,7 +4099,8 @@ static void flush_line(DisplayState *ds,
             }
             if (ds->line_num < e->shadow_nb_lines && !disable_crc) {
                 QELineShadow *ls;
-                uint64_t crc = ds->line_style + e->region_style * 0x100L + e->default_style * 0x10000L;
+                uint64_t crc = ds->line_style + e->region_style * 0x100L +
+                    e->window_style * 0x10000L + e->flags * 0x1000000L;
 
                 crc = compute_crc(fragments, sizeof(*fragments) * nb_fragments, crc);
                 crc = compute_crc(ds->line_chars, sizeof(*ds->line_chars) * ds->line_index, crc);
@@ -4105,15 +4120,7 @@ static void flush_line(DisplayState *ds,
         if (!no_display) {
             /* display */
             QEStyleDef default_style;
-#if 1
-            get_style(e, &default_style, ds->line_style);
-#else
-            default_style = qe_styles[QE_STYLE_DEFAULT];
-            if (e && e->default_style != 0)
-                apply_style(&default_style, e->default_style);
-            if (ds->line_style)
-                apply_style(&default_style, ds->line_style);
-#endif
+            get_style(&default_style, ds->window_style, ds->line_style);
             x = ds->x_start;
             y = ds->y;
 
@@ -4121,7 +4128,7 @@ static void flush_line(DisplayState *ds,
             /* XXX: should coalesce rectangles with identical style */
             if (ds->left_gutter > 0) {
                 /* erase space before the line display, aka left gutter */
-                get_style(e, &styledef, QE_STYLE_GUTTER);
+                get_style(&styledef, ds->window_style, QE_STYLE_GUTTER);
                 fill_rectangle(screen, e->xleft + x, e->ytop + y,
                                ds->left_gutter, line_height, styledef.bg_color);
             }
@@ -4130,13 +4137,9 @@ static void flush_line(DisplayState *ds,
             // XXX: handle curline_style and other line styles
             for (i = 0; i < nb_fragments && x < x1; i++) {
                 frag = &fragments[i];
-#if 0
-                get_style(e, &styledef, frag->style);
-#else
                 styledef = default_style;
                 if (frag->style)
                     apply_style(&styledef, frag->style);
-#endif
                 // XXX: should not fill if transparent
                 fill_rectangle(screen, e->xleft + x, e->ytop + y,
                                frag->width, line_height, styledef.bg_color);
@@ -4149,7 +4152,7 @@ static void flush_line(DisplayState *ds,
             }
             if (x1 < e->width) {
                 /* right gutter like space beyond terminal right margin */
-                get_style(e, &styledef, QE_STYLE_GUTTER);
+                get_style(&styledef, ds->window_style, QE_STYLE_GUTTER);
                 fill_rectangle(screen, e->xleft + x1, e->ytop + y,
                                e->width - x1, line_height, styledef.bg_color);
             }
@@ -4162,13 +4165,9 @@ static void flush_line(DisplayState *ds,
                 frag = &fragments[i];
                 x += frag->width;
                 if (x > 0) {
-#if 0
-                    get_style(e, &styledef, frag->style);
-#else
                     styledef = default_style;
                     if (frag->style)
                         apply_style(&styledef, frag->style);
-#endif
                     font = select_font(screen,
                                        styledef.font_style, styledef.font_size);
                     draw_text(screen, font,
@@ -4361,7 +4360,7 @@ static void flush_fragment(DisplayState *ds)
     }
 
     style = ds->last_style;
-    get_style(ds->edit_state, &styledef, style);
+    get_style(&styledef, ds->window_style, style);
     /* select font according to current style */
     font = select_font(screen, styledef.font_style, styledef.font_size);
     j = ds->line_index;
@@ -5351,7 +5350,7 @@ static void generic_text_display(EditState *s)
     /* display the remaining region */
     if (ds->y < s->height) {
         QEStyleDef default_style;
-        get_style(s, &default_style, QE_STYLE_DEFAULT);
+        get_style(&default_style, ds->window_style, QE_STYLE_DEFAULT);
         fill_rectangle(s->screen, s->xleft, s->ytop + ds->y,
                        s->width, s->height - ds->y,
                        default_style.bg_color);
@@ -5973,6 +5972,15 @@ void qe_display(QEmacsState *qs)
         }
     }
 
+    if (qs->complete_refresh) {
+        // erase status area
+        QEStyleDef styledef;
+        get_style(&styledef, QE_STYLE_STATUS, 0);
+        fill_rectangle(qs->screen, 0, qs->screen->height - qs->status_height,
+                       qs->screen->width, qs->status_height,
+                       styledef.bg_color);
+    }
+
     /* refresh normal windows and minibuf with popup kludge */
     for (s = qs->first_window; s != NULL; s = s->next_window) {
         if (s->flags & WF_POPUP)
@@ -6010,13 +6018,11 @@ void qe_display(QEmacsState *qs)
 
         if (*qs->status_shadow && !has_minibuf) {
             print_at_byte(qs->screen, x, y, width, height,
-                          qs->status_shadow, QE_STYLE_STATUS);
+                          qs->status_shadow, QE_STYLE_STATUS, 0, PB_DEFAULT);
         }
         if (*qs->diag_shadow) {
-            int w = strlen(qs->diag_shadow) + 1;
-            w *= get_glyph_width(qs->screen, NULL, QE_STYLE_STATUS, '0');
-            print_at_byte(qs->screen, x + width - w, y, w, height,
-                          qs->diag_shadow, QE_STYLE_STATUS);
+            print_at_byte(qs->screen, x, y, width, height,
+                          qs->diag_shadow, QE_STYLE_STATUS, 0, PB_RIGHT);
         }
     }
 
@@ -6867,12 +6873,29 @@ static void qe_key_process(QEmacsState *qs, int key)
             }
             exec_command(s, d, argval, key);
             if (s != qs->active_window || s->b != this_buffer) {
+                if (!qs->active_window && !(qs->active_window = qs->first_window)) {
+                    /* no window left: nothing further to do */
+                    return;
+                }
                 if (qe_check_window(qs, &s)) {
-                    /* end multi-cursor session upto window or buffer change */
+                    /* end multi-cursor session upon window or buffer change */
                     s->multi_cursor_active = 0;
                 }
-                if (!qs->key_ctx.grab_key_cb && qs->active_window) {
-                    qe_check_buffer_file(qs->active_window->b, CBF_CHECK);
+                s = qs->active_window;
+                if (!(s->flags & (WF_MINIBUF | WF_POPUP))) {
+                    /* update active window flag */
+                    EditState *e;
+                    for (e = qs->first_window; e; e = e->next_window) {
+                        if (e->flags & WF_ACTIVE) {
+                            e->flags &= ~WF_ACTIVE;
+                            e->borders_invalid = 1;
+                        }
+                    }
+                    s->flags |= WF_ACTIVE;
+                    s->borders_invalid = 1;
+                }
+                if (!qs->key_ctx.grab_key_cb) {
+                    qe_check_buffer_file(s->b, CBF_CHECK);
                 }
             } else
             if (multi_cursor_active) {
@@ -6930,19 +6953,32 @@ static void qe_key_process(QEmacsState *qs, int key)
 }
 
 /* Print a UTF-8 encoded buffer as unicode */
-void print_at_byte(QEditScreen *screen,
-                   int x, int y, int width, int height,
-                   const char *str, QETermStyle style)
+static void print_at_byte(QEditScreen *screen,
+                          int x, int y, int width, int height,
+                          const char *str, QETermStyle style1,
+                          QETermStyle style2, int flags)
 {
     char32_t ubuf[MAX_SCREEN_WIDTH];
-    int len;
+    int len, space = 0, w;
     QEStyleDef styledef;
+    QECharMetrics metrics;
     QEFont *font;
     CSSRect rect;
 
     len = utf8_to_char32(ubuf, countof(ubuf), str);
-    get_style(NULL, &styledef, style);
+    get_style(&styledef, style1, style2);
+    font = select_font(screen, styledef.font_style, styledef.font_size);
 
+    if (flags & PB_RIGHT) {
+        char32_t buf[1];
+        buf[0] = '0';
+        text_metrics(screen, font, &metrics, buf, 1);
+        space = metrics.width;
+        text_metrics(screen, font, &metrics, ubuf, len);
+        w = min_int(space + metrics.width, width);
+        x += width - w;
+        width = w;
+    }
     /* clip rectangle */
     rect.x1 = x;
     rect.y1 = y;
@@ -6952,8 +6988,8 @@ void print_at_byte(QEditScreen *screen,
 
     /* start rectangle */
     fill_rectangle(screen, x, y, width, height, styledef.bg_color);
-    font = select_font(screen, styledef.font_style, styledef.font_size);
-    draw_text(screen, font, x, y + font->ascent, ubuf, len, styledef.fg_color);
+    if (!(flags & PB_NO_TEXT))
+        draw_text(screen, font, x + space, y + font->ascent, ubuf, len, styledef.fg_color);
     release_font(screen, font);
 }
 
@@ -7085,18 +7121,16 @@ void put_status(EditState *s, const char *fmt, ...)
         if (diag) {
             if (force || !strequal(p, qs->diag_shadow)) {
                 /* right align display and overwrite last diag message */
-                int w = strlen(qs->diag_shadow);
-                w = snprintf(qs->diag_shadow, sizeof(qs->diag_shadow),
-                             "%*s", w, p) + 1;
-                w *= get_glyph_width(qs->screen, NULL, QE_STYLE_STATUS, '0');
-                print_at_byte(qs->screen, x + width - w, y, w, height,
-                              qs->diag_shadow, QE_STYLE_STATUS);
+                print_at_byte(qs->screen, x, y, width, height,
+                              qs->diag_shadow, QE_STYLE_STATUS, 0, PB_RIGHT | PB_NO_TEXT);
                 pstrcpy(qs->diag_shadow, sizeof(qs->diag_shadow), p);
+                print_at_byte(qs->screen, x, y, width, height,
+                              qs->diag_shadow, QE_STYLE_STATUS, 0, PB_RIGHT);
             }
         } else {
             if (force || !strequal(p, qs->status_shadow)) {
                 print_at_byte(qs->screen, x, y, width, height,
-                              p, QE_STYLE_STATUS);
+                              p, QE_STYLE_STATUS, 0, PB_DEFAULT);
                 pstrcpy(qs->status_shadow, sizeof(qs->status_shadow), p);
             }
         }
@@ -9767,7 +9801,7 @@ int get_glyph_width(QEditScreen *screen, EditState *s, QETermStyle style, char32
     QEFont *font;
     int width = 1;
 
-    get_style(s, &styledef, style);
+    get_style(&styledef, s ? s->default_style : QE_STYLE_WINDOW, style);
     font = select_font(screen, styledef.font_style, styledef.font_size);
     if (font) {
         width = glyph_width(screen, font, c);
@@ -9782,7 +9816,7 @@ int get_line_height(QEditScreen *screen, EditState *s, QETermStyle style)
     QEFont *font;
     int height = 1;
 
-    get_style(s, &styledef, style);
+    get_style(&styledef, s ? s->default_style : QE_STYLE_WINDOW, style);
     font = select_font(screen, styledef.font_style, styledef.font_size);
     if (font) {
         height = font->ascent + font->descent;
@@ -12281,7 +12315,7 @@ static int qe_init(void *opaque)
     qe_data_init(qs);
     charset_init(qs);
     qe_input_methods_init(qs);
-    colors_init();
+    colors_init(qe_styles[0].fg_color, qe_styles[0].bg_color);
 
 #ifdef CONFIG_ALL_KMAPS
     if (qe_find_resource_file(qs, filename, sizeof(filename), "kmaps") >= 0)

--- a/qe.h
+++ b/qe.h
@@ -757,6 +757,7 @@ struct EditState {
     ModeDef *colorize_mode;
 
     QETermStyle default_style;  /* default text style */
+    QETermStyle window_style;  /* style for the current display */
 
     /* after this limit, the fields are not saved into the buffer */
     int end_of_saved_data;
@@ -807,6 +808,7 @@ struct EditState {
 #define WF_POPLEFT    0x0008 /* left side window */
 #define WF_HIDDEN     0x0010 /* hidden window, used for temporary changes */
 #define WF_MINIBUF    0x0020 /* true if single line editing */
+#define WF_ACTIVE     0x0040 /* true if window is active or minibuf target */
 #define WF_FILELIST   0x1000 /* window is interactive file list */
 
     OWNED char *prompt;  /* optional window prompt, utf8 */
@@ -902,6 +904,7 @@ struct ModeDef {
     int colorize_flags;
     int auto_indent;
     int default_wrap;
+    QETermStyle default_style;
 
     /* common functions are defined here */
     /* TODO: Should have single move function with move type and argument */
@@ -1327,6 +1330,7 @@ struct DisplayState {
     EditState *edit_state;
     QETermStyle style;   /* current style for display_printf... */
     QETermStyle line_style; /* style of the current line... */
+    QETermStyle window_style;
 
 #if 0
     QEFont *font;
@@ -1721,7 +1725,7 @@ void fill_window_slack(EditState *s, int x, int y, int w, int h, int color);
 int find_style_index(const char *name);
 QEStyleDef *find_style(const char *name);
 void style_complete(CompleteState *cp, CompleteFunc enumerate);
-void get_style(EditState *e, QEStyleDef *stp, QETermStyle style);
+void get_style(QEStyleDef *stp, QETermStyle window_style, QETermStyle style);
 void style_property_complete(CompleteState *cp, CompleteFunc enumerate);
 int find_style_property(const char *name);
 void do_define_color(EditState *e, const char *name, const char *value);
@@ -1905,9 +1909,10 @@ void do_show_bindings(EditState *s, const char *cmd_name);
 void do_describe_bindings(EditState *s, int argval);
 void do_apropos(EditState *s, const char *str);
 
-int qe_term_get_style(QETermStyle *style, const char *str);
-int qe_term_style_string(char *dest, size_t size, QETermStyle style);
+int qe_styledef_parse(QEStyleDef *stp, const char *str);
 int qe_styledef_string(char *dest, size_t size, const QEStyleDef *stp);
+int qe_term_style_parse(QETermStyle *style, const char *str);
+int qe_term_style_string(char *dest, size_t size, QETermStyle style);
 int color_print_entry(CompleteState *cp, EditState *s, const char *name);
 int style_print_entry(CompleteState *cp, EditState *s, const char *name);
 

--- a/qestyles.h
+++ b/qestyles.h
@@ -5,10 +5,18 @@
               QERGB(0xf8, 0xd8, 0xb0), QERGB(0x00, 0x00, 0x00), QE_FONT_FAMILY_FIXED, 12)
 
     /* system styles */
+    STYLE_DEF(QE_STYLE_WINDOW, "window", /* default */
+              COLOR_DEFAULT, COLOR_TRANSPARENT, 0, 0)
+    STYLE_DEF(QE_STYLE_WINDOW_INACTIVE, "window-inactive", /* same */
+              COLOR_DEFAULT, COLOR_TRANSPARENT, 0, 0)
     STYLE_DEF(QE_STYLE_MODE_LINE, "mode-line", /* black on grey88 */
               QERGB(0x00, 0x00, 0x00), QERGB(0xe0, 0xe0, 0xe0), 0, 0)
+    STYLE_DEF(QE_STYLE_MODE_LINE_INACTIVE, "mode-line-inactive", /* same */
+              COLOR_DEFAULT, COLOR_TRANSPARENT, 0, 0)
     STYLE_DEF(QE_STYLE_WINDOW_BORDER, "window-border", /* black on grey88 */
               QERGB(0x00, 0x00, 0x00), QERGB(0xe0, 0xe0, 0xe0), 0, 0)
+    STYLE_DEF(QE_STYLE_WINDOW_BORDER_INACTIVE, "window-border-inactive", /* same */
+              COLOR_DEFAULT, COLOR_TRANSPARENT, 0, 0)
     STYLE_DEF(QE_STYLE_MINIBUF, "minibuf", /* yellow */
               QERGB(0xff, 0xff, 0x00), COLOR_TRANSPARENT, 0, 0)
     STYLE_DEF(QE_STYLE_STATUS, "status", /* yellow */
@@ -25,10 +33,8 @@
               QERGB(0x00, 0x00, 0x00), QERGB(0xf8, 0xd8, 0xb0), 0, 0)
     STYLE_DEF(QE_STYLE_SELECTION, "selection", /* white on blue */
               QERGB(0xff, 0xff, 0xff), QERGB(0x00, 0x00, 0xff), 0, 0)
-    STYLE_DEF(QE_STYLE_ERROR_LOCATION, "error-location",
-              QERGB(0xff, 0xff, 0xff), COLOR_TRANSPARENT,
-              QE_FONT_STYLE_BOLD, 0)
-
+    STYLE_DEF(QE_STYLE_ERROR_LOCATION, "error-location", /* bright-white */
+              QERGB(0xff, 0xff, 0xff), COLOR_TRANSPARENT, QE_FONT_STYLE_BOLD, 0)
 
     /* Generic syntax coloring styles */
     STYLE_DEF(QE_STYLE_COMMENT, "comment", /* #f84400 */
@@ -65,6 +71,10 @@
               QERGB(0xe0, 0xe0, 0xe0), QERGB(0xf0, 0x00, 0xf0), 0, 0)
     STYLE_DEF(QE_STYLE_BLANK_HILITE, "blank-hilite", /* black on red */
               QERGB(0x00, 0x00, 0x00), QERGB(0xff, 0x00, 0x00), 0, 0)
+
+    /* shell windows */
+    STYLE_DEF(QE_STYLE_SHELL, "shell", /* grey */
+              QERGB(0xbb, 0xbb, 0xbb), COLOR_TRANSPARENT, 0, 0)
 
     /* diff/patch styles */
     STYLE_DEF(QE_STYLE_DIFF_HEAD, "diff-head", /* bold bright white */

--- a/variables.c
+++ b/variables.c
@@ -326,7 +326,7 @@ static QVarType qe_variable_set_value_style(EditState *s, VarDef *vp, void *ptr,
                                             const char *value, int num)
 {
     QETermStyle style = num;
-    if (value && qe_term_get_style(&style, value)) {
+    if (value && qe_term_style_parse(&style, value)) {
         const char *p;
         style = strtol_c(value, &p, 0);
         if (*p)

--- a/x11.c
+++ b/x11.c
@@ -238,7 +238,7 @@ static int x11_dpy_init(QEditScreen *s, QEmacsState *qs, int w, int h)
     /* At this point, we should be able to ask for metrics */
     if (font_ptsize)
         qe_styles[0].font_size = font_ptsize;
-    get_style(NULL, &default_style, 0);
+    get_style(&default_style, 0, 0);
     font = x11_dpy_open_font(s, default_style.font_style,
                           default_style.font_size);
     if (!font) {


### PR DESCRIPTION
Vastly improve window style handling:
* fix status and minibuf style handling
* add inactive window styles (window, border and mode-line)
* add commands: `set-foreground-color`, `set-background-color` `set-default-style`
* add styles for `window`, `window-inactive`, `window-border-inactive`, `mode-line-inactive`, `terminal`
* use custom colors for COLOR_TRANSPARENT and terminal *original pair*
* terminal background color is default background color
* change `get_style` argument types and order
* add `qe_styledef_parse` to construct full styles from text
* rename `qe_term_get_style` -> `qe_term_style_parse`
* pass 2 styles and extra flags to `print_at_bytes` to handle alignment correctly