### PR TITLE
Improve shell color handling

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -1513,6 +1513,9 @@ char32_t eb_nextc(EditBuffer *b, int offset, int *next_ptr)
 QETermStyle eb_get_style(EditBuffer *b, int offset)
 {
     if (b->b_styles) {
+        if (offset >= b->total_size && b->total_size > 0)
+            offset = b->total_size - (1 << b->style_shift);
+        // Read from style buffer and zero extend (endianness dependent).
         if (b->style_shift == 3) {
             uint64_t style = 0;
             eb_read(b->b_styles, (offset >> b->char_shift) << 3, &style, 8);

--- a/color.c
+++ b/color.c
@@ -1455,7 +1455,7 @@ int css_get_color(QEColor *color_ptr, const char *p)
                 v |= (v << 4);
             while (len --> 2)
                 v >>= 4;
-            rgba[i] = v | (v << 4);
+            rgba[i] = v;
             if (*p == '/')
                 p++;
         }

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -879,7 +879,8 @@ static int qe_term_goto_pos(ShellState *s, int offset, int destx, int desty, int
             if (flags & TG_NOEXTEND)
                 break;
             /* XXX: color may be wrong */
-            s->b->cur_style = QE_STYLE_DEFAULT;
+            //s->b->cur_style = QE_STYLE_DEFAULT;
+            s->b->cur_style = QE_TERM_COMPOSITE | QE_TERM_MAKE_COLOR(QE_TERM_DEF_FG, QE_TERM_DEF_BG);
             //qe_term_set_style(s);
             if (y < desty) {
                 // XXX: potential problem if previous line has s->cols characters
@@ -904,7 +905,8 @@ static int qe_term_goto_pos(ShellState *s, int offset, int destx, int desty, int
                 } else {
                     if (flags & TG_NOEXTEND)
                         break;
-                    s->b->cur_style = QE_STYLE_DEFAULT;
+                    //s->b->cur_style = QE_STYLE_DEFAULT;
+                    s->b->cur_style = QE_TERM_COMPOSITE | QE_TERM_MAKE_COLOR(QE_TERM_DEF_FG, QE_TERM_DEF_BG);
                     offset += eb_insert_spaces(s->b, offset, destx - x);
                     x = destx;
                 }
@@ -1359,23 +1361,12 @@ static inline ShellState *shell_get_state(EditState *e, int status)
 static void shell_display_hook(EditState *e)
 {
     ShellState *s;
-    QEColor bg_color, fg_color;
 
     if (e->interactive) {
         if ((s = shell_get_state(e, 0)) != NULL)
             e->offset = s->cur_offset;
         if (s->use_alternate_screen)
             e->offset_top = s->alternate_screen_top;
-    }
-    bg_color = qe_styles[QE_STYLE_SHELL].bg_color;
-    if (!bg_color) bg_color = qe_styles[QE_STYLE_DEFAULT].bg_color;
-    fg_color = qe_styles[QE_STYLE_SHELL].fg_color;
-    if (!fg_color) fg_color = qe_styles[QE_STYLE_DEFAULT].fg_color;
-
-    if (fg_color != custom_colors[1] || bg_color != custom_colors[2]) {
-        custom_colors[1] = fg_color;
-        custom_colors[2] = bg_color;
-        edit_invalidate(e, 0);
     }
 }
 
@@ -1884,7 +1875,7 @@ static void qe_term_emulate(ShellState *s, int c)
             break;
         }
         /* Stop string on \a (^G) or ST (ESC \) */
-        if (!(c == '\007' || c == 0234 || (s->lastc == 27 && c == '\\'))) {
+        if (!(c == '\007' || c == 0x9c || (s->lastc == 27 && c == '\\'))) {
             s->lastc = c;
             /* skip ';' following OSC number */
             if (s->osc_len > 0 || (c != ';')) {
@@ -1935,6 +1926,10 @@ static void qe_term_emulate(ShellState *s, int c)
            - OSC 15; c; name... ST  Change colors starting with Tek foreground
            - OSC 16; c; name... ST  Change colors starting with Tek background
            - OSC 17; c; name... ST  Change colors starting with highlight
+           - OSC 22; Pt ST Change pointer cursor shape to Pt.  The parameter
+             Pt sets the pointerShape resource.  If Pt is empty, or does not
+             match any of the standard names, xterm uses the resource's
+             default "xterm" shape.
            - OSC 46; Pt ST  Change Log File to Pt (normally disabled by a
            compile-time option)
            - OSC 50; Pt ST  Set Font to Pt. If Pt begins with a "#", index in
@@ -1983,6 +1978,29 @@ static void qe_term_emulate(ShellState *s, int c)
                 shell_add_cwd(s->b, s->b->offset, cwd, 0);
             }
             break;
+        case 10:
+        case 11:
+            {
+                char *p = s->osc_buf;
+                QEColor color;
+                int n;
+                for (n = s->params[0]; n <= 11; n++) {
+                    char *p1 = strchr(p, ';');
+                    if (p1)
+                        *p1 = '\0';
+                    if (!*p || css_get_color(&color, p))
+                        break;
+                    if (n == 10)
+                        qe_styles[QE_STYLE_SHELL].fg_color = color;
+                    else
+                        qe_styles[QE_STYLE_SHELL].bg_color = color;
+                    if (!p1)
+                        break;
+                    p = p1 + 1;
+                    p += (*p == ';');
+                }
+                break;
+            }
         default:
             TRACE_PRINTF(s, "unhandled string: %.*s", min_int(s->osc_len, 32), s->osc_buf);
             break;
@@ -2456,7 +2474,7 @@ static void qe_term_emulate(ShellState *s, int c)
                 qe_term_write(s, buf2, -1);
             }
             break;
-        case 'p':  /* DECSCL: Set conformance level. */
+        case 'p':  /* DECSCL: Set conformance level. Also redefine keyboard keys */
         case 'q':  /* DECLL: Load LEDs. */
         case ESC2(' ','q'): /* Set cursor style (DECSCUSR, VT520). */
             goto unhandled;

--- a/qe.c
+++ b/qe.c
@@ -4102,6 +4102,7 @@ static void flush_line(DisplayState *ds,
                 uint64_t crc = ds->line_style + e->region_style * 0x100L +
                     e->window_style * 0x10000L + e->flags * 0x1000000L;
 
+                // XXX: should add styles to crc?
                 crc = compute_crc(fragments, sizeof(*fragments) * nb_fragments, crc);
                 crc = compute_crc(ds->line_chars, sizeof(*ds->line_chars) * ds->line_index, crc);
                 ls = &e->line_shadow[ds->line_num];
@@ -4146,9 +4147,11 @@ static void flush_line(DisplayState *ds,
                 x += frag->width;
             }
             if (x < x1 && last != -1) {
-                /* XXX: color may be inappropriate for terminal mode */
+                styledef = default_style;
+                if (ds->eol_style)
+                    apply_style(&styledef, ds->eol_style);
                 fill_rectangle(screen, e->xleft + x, e->ytop + y,
-                               x1 - x, line_height, default_style.bg_color);
+                               x1 - x, line_height, styledef.bg_color);
             }
             if (x1 < e->width) {
                 /* right gutter like space beyond terminal right margin */
@@ -4188,6 +4191,7 @@ static void flush_line(DisplayState *ds,
                     markbuf[0] = '\\';   /* LTR eol mark */
                     x = ds->width;        /* displayed at the right border */
                 }
+                /* XXX: should use style of last character? */
                 font = select_font(screen,
                                    default_style.font_style,
                                    default_style.font_size);
@@ -4825,7 +4829,7 @@ static int get_staticly_colorized_line(QEColorizeContext *cp,
 {
     int len = cp_get_line(cp, offset, offset_ptr);
     int i;
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len + 1; i++) {
         cp->sbuf[i] = eb_get_style(cp->b, offset);
         offset = eb_next(cp->b, offset);
     }
@@ -4912,7 +4916,7 @@ static int syntax_get_colorized_line(QEColorizeContext *cp,
         SET_STYLE1(cp->sbuf, 0, QE_STYLE_PREPROCESS);
         cp->offset = eb_next(b, cp->offset);
     }
-    cp->combine_stop = len - bom;
+    cp->combine_stop = len + 1 - bom;
     cp->cur_pos -= bom;
     cp->mode_flags = s->colorize_mode->flags;
     cp_colorize_line(cp, cp->buf, bom, len, cp->sbuf, s->colorize_mode);
@@ -5148,6 +5152,7 @@ int text_display_line(EditState *s, DisplayState *ds, int offset)
 #endif
 
     ds->line_style = cp->line_style;
+    ds->eol_style = cp->sbuf[colored_nb_chars];
     bd = embeds + 1;
     char_index = 0;
     for (;;) {
@@ -5939,11 +5944,24 @@ void qe_display(QEmacsState *qs)
     int start_time, elapsed_time;
     int invalidate_popups = qs->complete_refresh;
     static int last_popup_time;
+    QEColor term_bg_color, term_fg_color;
 
     start_time = get_clock_ms();
 
     if (qs->active_window)
         qs->active_window->b->atime = start_time;
+
+    /* detect global palette changes */
+    term_bg_color = qe_styles[QE_STYLE_SHELL].bg_color;
+    if (!term_bg_color) term_bg_color = qe_styles[QE_STYLE_DEFAULT].bg_color;
+    term_fg_color = qe_styles[QE_STYLE_SHELL].fg_color;
+    if (!term_fg_color) term_fg_color = qe_styles[QE_STYLE_DEFAULT].fg_color;
+
+    if (term_fg_color != custom_colors[1] || term_bg_color != custom_colors[2]) {
+        custom_colors[1] = term_fg_color;
+        custom_colors[2] = term_bg_color;
+        qs->complete_refresh = 1;
+    }
 
     /* first call hooks for mode specific fixups */
     for (s = qs->first_window; s != NULL; s = s->next_window) {

--- a/qe.h
+++ b/qe.h
@@ -1331,6 +1331,7 @@ struct DisplayState {
     QETermStyle style;   /* current style for display_printf... */
     QETermStyle line_style; /* style of the current line... */
     QETermStyle window_style;
+    QETermStyle eol_style;
 
 #if 0
     QEFont *font;


### PR DESCRIPTION
* add `eol_style` in `DisplayState`
* use style of newline character for end of line
* use style of last character if any for end of buffer style
* use current style for TAB expansion
* accept OSC escape sequences for default color redefinition
* fix `css_get_color` parser for `rgb:xx/xx/xx` format
* force complete refresh upon default terminal color updates