### PR TITLE
Improve asynchronous I/O handlers

### DIFF
--- a/cutils.h
+++ b/cutils.h
@@ -847,6 +847,8 @@ static inline void qe__list_del(struct list_head *prev, struct list_head *next)
 
 #define QE_LIST_HEAD(name) struct list_head name = { &name, &name }
 
+#define QE_LIST_INIT(head) (head).prev = (head).next = &(head)
+
 /* add at the head */
 #define list_add(elem, head) \
    qe__list_add((struct list_head *)elem, head, (head)->next)

--- a/haiku.cpp
+++ b/haiku.cpp
@@ -284,7 +284,7 @@ static int haiku_init(QEditScreen *s, int w, int h)
     ctx->events_rd = event_pipe[0];
     ctx->events_wr = events_wr = event_pipe[1];
 
-    set_read_handler(event_pipe[0], haiku_handle_event, s);
+    url_set_read_handler(s->qs->up, event_pipe[0], haiku_handle_event, s);
 
     ctx->font = BFont(be_fixed_font);
 

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2670,11 +2670,11 @@ static void shell_mode_free(EditBuffer *b, void *state)
             /* if still not killed, then try harder (useful for shells) */
             sig = SIGKILL;
         }
-        set_pid_handler(s->pid, NULL, NULL);
+        url_set_pid_handler(b->qs->up, s->pid, NULL, NULL);
         s->pid = -1;
     }
     if (s->pty_fd >= 0) {
-        set_read_handler(s->pty_fd, NULL, NULL);
+        url_set_read_handler(b->qs->up, s->pty_fd, NULL, NULL);
         close(s->pty_fd);
         s->pty_fd = -1;
     }
@@ -2697,7 +2697,7 @@ static void shell_pid_cb(void *opaque, int status)
 
     b = s->b;
     qs = s->base.qs;
-    set_pid_handler(s->pid, NULL, NULL);
+    url_set_pid_handler(qs->up, s->pid, NULL, NULL);
     s->exit_status = status;
     s->pid = -1;
 
@@ -2766,7 +2766,7 @@ static void shell_close(ShellState *s)
     }
 
     if (s->pty_fd >= 0) {
-        set_read_handler(s->pty_fd, NULL, NULL);
+        url_set_read_handler(qs->up, s->pty_fd, NULL, NULL);
         close(s->pty_fd);
         s->pty_fd = -1;
     }
@@ -2887,8 +2887,8 @@ EditBuffer *qe_new_shell_buffer(QEmacsState *qs, EditBuffer *b0, EditState *e,
     }
 
     /* XXX: ShellState life cycle is bogus */
-    set_read_handler(s->pty_fd, shell_read_cb, s);
-    set_pid_handler(s->pid, shell_pid_cb, s);
+    url_set_read_handler(qs->up, s->pty_fd, shell_read_cb, s);
+    url_set_pid_handler(qs->up, s->pid, shell_pid_cb, s);
     return b;
 }
 

--- a/modes/video.c
+++ b/modes/video.c
@@ -81,7 +81,7 @@ typedef struct VideoState {
     pthread_mutex_t pictq_mutex;
     pthread_cond_t pictq_cond;
 
-    QETimer *video_timer;
+    URLTimer *video_timer;
 } VideoState;
 
 static int video_buffer_load(EditBuffer *b, FILE *f)
@@ -231,12 +231,12 @@ static void video_refresh_timer(void *opaque)
     if (is->video_st) {
         if (is->pictq_size == 0) {
             /* if no picture, need to wait */
-            is->video_timer = qe_add_timer(40, s, video_refresh_timer);
+            is->video_timer = url_add_timer(qs->up, 40, s, video_refresh_timer);
         } else {
             vp = &is->pictq[is->pictq_rindex];
 
             /* launch timer for next picture */
-            is->video_timer = qe_add_timer(vp->delay, s, video_refresh_timer);
+            is->video_timer = url_add_timer(qs->up, vp->delay, s, video_refresh_timer);
 
             /* invalidate window */
             edit_invalidate(s, 0);
@@ -256,7 +256,7 @@ static void video_refresh_timer(void *opaque)
         }
     } else if (is->audio_st) {
         /* draw the next audio frame */
-        is->video_timer = qe_add_timer(40, s, video_refresh_timer);
+        is->video_timer = url_add_timer(qs->up, 40, s, video_refresh_timer);
 
         /* if only audio stream, then display the audio bars (better
            than nothing, just to test the implementation */
@@ -268,7 +268,7 @@ static void video_refresh_timer(void *opaque)
         /* display picture */
         qe_display(qs);
     } else {
-        is->video_timer = qe_add_timer(100, s, video_refresh_timer);
+        is->video_timer = url_add_timer(qs->up, 100, s, video_refresh_timer);
     }
 }
 
@@ -451,7 +451,7 @@ static int output_picture(VideoState *is, AVPicture *src_pict)
 
         /* the allocation must be done in the main thread to avoid
            locking problems */
-        qe_add_timer(0, is, alloc_picture);
+        url_add_timer(s->qs->up, 0, is, alloc_picture);
 
         /* wait until the picture is allocated */
         pthread_mutex_lock(&is->pictq_mutex);
@@ -844,7 +844,7 @@ static int video_mode_init(EditState *s, EditBuffer *b, int flags)
         pthread_cond_init(&is->pictq_cond, NULL);
 
         /* add the refresh timer to draw the picture */
-        is->video_timer = qe_add_timer(0, s, video_refresh_timer);
+        is->video_timer = url_add_timer(qs->up, 0, s, video_refresh_timer);
 
         /* if there is already a window with this video playing, then we
            stop this new instance (C-x 2 case) */

--- a/qe.c
+++ b/qe.c
@@ -9841,7 +9841,7 @@ void do_exit_qemacs(EditState *s, int argval)
     QEmacsState *qs = s->qs;
 
     if (argval != NO_ARG) {
-        url_exit();
+        url_exit(qs->up);
         return;
     }
 
@@ -9852,7 +9852,7 @@ void do_exit_qemacs(EditState *s, int argval)
     if (use_session_file)
         do_save_session(qs->active_window, 0);
 #endif
-    url_exit();
+    url_exit(qs->up);
 }
 
 /*----------------*/
@@ -12329,12 +12329,8 @@ static CompletionDef charset_completion = {
 };
 
 /* init function */
-static int qe_init(void *opaque)
+static int qe_init(QEmacsState *qs, int argc, char **argv)
 {
-    QEArgs *args = opaque;
-    QEmacsState *qs = args->qs;
-    int argc = args->argc;
-    char **argv = args->argv;
     EditState *s;
     EditBuffer *b;
     QEDisplay *dpy;
@@ -12346,6 +12342,9 @@ static int qe_init(void *opaque)
     char filename[MAX_FILENAME_SIZE];
 #endif
 
+    qs->up = url_init();
+    if (!qs->up)
+        return -1;
     qs->ec.function = "qe-init";
     qs->macro_key_index = -1; /* no macro executing */
     qs->ungot_key = -1; /* no unget key */
@@ -12546,14 +12545,10 @@ int main(int argc, char **argv)
 #endif
 {
     QEmacsState *qs = &qe_state;
-    QEArgs args;
-    int status;
+    int status = qe_init(qs, argc, argv);
 
-    args.qs = qs;
-    args.argc = argc;
-    args.argv = argv;
-
-    status = url_main_loop(qe_init, &args);
+    if (!status)
+        status = url_main_loop(qs->up);
 
 #ifdef CONFIG_ALL_KMAPS
     /* unmap/free input methods file */

--- a/qe.h
+++ b/qe.h
@@ -78,7 +78,6 @@ typedef struct DisplayState DisplayState;
 typedef struct ModeProbeData ModeProbeData;
 typedef struct QEModeData QEModeData;
 typedef struct ModeDef ModeDef;
-typedef struct QETimer QETimer;
 typedef struct QEColorizeContext QEColorizeContext;
 typedef struct KeyDef KeyDef;
 typedef struct InputMethod InputMethod;
@@ -106,28 +105,21 @@ typedef struct QEProperty QEProperty;
 extern const char str_version[];
 extern const char str_credits[];
 
-/* low level I/O events */
-void set_read_handler(int fd, void (*cb)(void *opaque), void *opaque);
-void set_write_handler(int fd, void (*cb)(void *opaque), void *opaque);
-int set_pid_handler(int pid,
-                    void (*cb)(void *opaque, int status), void *opaque);
-void url_exit(void);
-void url_redisplay(QEditScreen *s);
-void register_bottom_half(void (*cb)(void *opaque), void *opaque);
-void unregister_bottom_half(void (*cb)(void *opaque), void *opaque);
+/* Asynchronous I/O handling modelled after liburlio */
+typedef struct URLState URLState;
+typedef struct URLTimer URLTimer;
 
-QETimer *qe_add_timer(int delay, void *opaque, void (*cb)(void *opaque));
-void qe_kill_timer(QETimer **tip);
-
-/* opaque argument for url_main_loop */
-typedef struct QEArgs {
-    QEmacsState *qs;
-    int argc;
-    char **argv;
-} QEArgs;
-
-/* main loop for Unix programs using liburlio */
-int url_main_loop(int (*init)(void *opaque), void *opaque);
+URLState *url_init(void);
+int url_main_loop(URLState *up);
+void url_exit(URLState *up);
+int url_set_read_handler(URLState *up, int fd, void (*cb)(void *opaque), void *opaque);
+int url_set_write_handler(URLState *up, int fd, void (*cb)(void *opaque), void *opaque);
+int url_set_pid_handler(URLState *up, int pid, void (*cb)(void *opaque, int status), void *opaque);
+int url_set_tail_handler(URLState *up, void (*cb)(void *opaque), void *opaque);
+int url_register_bottom_half(URLState *up, void (*cb)(void *opaque), void *opaque);
+void url_unregister_bottom_half(URLState *up, void (*cb)(void *opaque), void *opaque);
+URLTimer *url_add_timer(URLState *up, int delay, void *opaque, void (*cb)(void *opaque));
+void url_kill_timer(URLState *up, URLTimer **tip);
 
 int get_clock_ms(void);
 int get_clock_usec(void);
@@ -1012,6 +1004,7 @@ struct CmdDefArray {
 
 struct QEmacsState {
     QEditScreen *screen;
+    URLState *up;
     //struct QEDisplay *first_dpy;
     struct ModeDef *first_mode;
     struct KeyDef *first_key;
@@ -1022,7 +1015,6 @@ struct QEmacsState {
     struct CompletionDef *first_completion;
     struct HistoryEntry *first_history;
     //struct QECharset *first_charset;
-    //struct QETimer *first_timer;
     struct VarDef *first_variable;
     InputMethod *input_methods;
     EditState *first_window;

--- a/tty.c
+++ b/tty.c
@@ -597,7 +597,7 @@ static int tty_dpy_init(QEditScreen *s, QEmacsState *qs,
      * session. */
     fcntl(fileno(s->STDOUT), F_SETFL, 0);
 
-    set_read_handler(fileno(s->STDIN), tty_read_handler, s);
+    url_set_read_handler(qs->up, fileno(s->STDIN), tty_read_handler, s);
 
     tty_dpy_invalidate(s);
 
@@ -653,12 +653,21 @@ static void tty_term_resume(qe__unused__ int sig)
     tty_term_resize(0);
 }
 
+static void tty_term_redisplay(void *opaque) {
+    QEditScreen *s = opaque;
+    QEmacsState *qs = s->qs;
+    //qs->complete_refresh = 1;
+    do_refresh(qs->first_window);
+    qe_display(qs);
+}
+
 static void tty_term_resize(qe__unused__ int sig)
 {
     QEditScreen *s = tty_screen;
 
     if (s) {
-        url_redisplay(s);
+        s->qs->complete_refresh = 1;
+        url_set_tail_handler(s->qs->up, tty_term_redisplay, s);
     }
 }
 

--- a/unix.c
+++ b/unix.c
@@ -2,7 +2,7 @@
  * Unix main loop for QEmacs
  *
  * Copyright (c) 2002, 2003 Fabrice Bellard.
- * Copyright (c) 2000-2024 Charlie Gordon.
+ * Copyright (c) 2000-2026 Charlie Gordon.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,12 +37,12 @@ typedef int fdesc_t;
 
 /* NOTE: it is strongly inspirated from the 'links' browser API */
 
-typedef struct URLHandler {
+typedef struct IOHandler {
     void *read_opaque;
     void (*read_cb)(void *opaque);
     void *write_opaque;
     void (*write_cb)(void *opaque);
-} URLHandler;
+} IOHandler;
 
 typedef struct PidHandler {
     struct PidHandler *next, *prev;
@@ -57,59 +57,79 @@ typedef struct BottomHalfEntry {
     void *opaque;
 } BottomHalfEntry;
 
-struct QETimer {
+struct URLTimer {
     void *opaque;
     void (*cb)(void *opaque);
     int timeout;
-    struct QETimer *next;
+    struct URLTimer *next;
 };
 
-static fd_set url_rfds, url_wfds;
-static int url_fdmax;
-static URLHandler url_handlers[256];
-static int url_exit_request;
-static int url_display_request;
-static QE_LIST_HEAD(pid_handlers);
-static QE_LIST_HEAD(bottom_halves);
-static QETimer *first_timer;
+struct URLState {
+    fd_set rfds, wfds;
+    int nfds;
+    IOHandler handlers[256];
+    int exit_request;
+    void (*tail_cb)(void *opaque);
+    void *tail_opaque;
+    struct list_head pid_handlers;
+    struct list_head bottom_halves;
+    URLTimer *first_timer;
+};
 
-
-void set_read_handler(int fd, void (*cb)(void *opaque), void *opaque)
-{
-    url_handlers[fd].read_cb = cb;
-    url_handlers[fd].read_opaque = opaque;
-    if (cb) {
-        if (fd >= url_fdmax)
-            url_fdmax = fd;
-        FD_SET((fdesc_t)fd, &url_rfds);
-    } else {
-        FD_CLR((fdesc_t)fd, &url_rfds);
+URLState *url_init(void) {
+    URLState *up = qe_mallocz(URLState);
+    if (up) {
+        FD_ZERO(&up->rfds);
+        FD_ZERO(&up->wfds);
+        QE_LIST_INIT(up->pid_handlers);
+        QE_LIST_INIT(up->bottom_halves);
     }
+    return up;
 }
 
-void set_write_handler(int fd, void (*cb)(void *opaque), void *opaque)
+int url_set_read_handler(URLState *up, int fd, void (*cb)(void *opaque), void *opaque)
 {
-    url_handlers[fd].write_cb = cb;
-    url_handlers[fd].write_opaque = opaque;
+    if (fd < 0 || fd >= countof(up->handlers))
+        return -1;
+
+    up->handlers[fd].read_cb = cb;
+    up->handlers[fd].read_opaque = opaque;
     if (cb) {
-        if (fd >= url_fdmax)
-            url_fdmax = fd;
-        FD_SET((fdesc_t)fd, &url_wfds);
+        if (fd >= up->nfds)
+            up->nfds = fd + 1;
+        FD_SET((fdesc_t)fd, &up->rfds);
     } else {
-        FD_CLR((fdesc_t)fd, &url_wfds);
+        FD_CLR((fdesc_t)fd, &up->rfds);
     }
+    return 0;
+}
+
+int url_set_write_handler(URLState *up, int fd, void (*cb)(void *opaque), void *opaque)
+{
+    if (fd < 0 || fd >= countof(up->handlers))
+        return -1;
+
+    up->handlers[fd].write_cb = cb;
+    up->handlers[fd].write_opaque = opaque;
+    if (cb) {
+        if (fd >= up->nfds)
+            up->nfds = fd + 1;
+        FD_SET((fdesc_t)fd, &up->wfds);
+    } else {
+        FD_CLR((fdesc_t)fd, &up->wfds);
+    }
+    return 0;
 }
 
 /* register a callback which is called when process 'pid'
    terminates. When the callback is set to NULL, it is deleted */
 /* XXX: add consistency check ? */
-int set_pid_handler(int pid,
-                    void (*cb)(void *opaque, int status), void *opaque)
+int url_set_pid_handler(URLState *up, int pid, void (*cb)(void *opaque, int status), void *opaque)
 {
     PidHandler *p;
 
     if (cb == NULL) {
-        list_for_each(p, &pid_handlers) {
+        list_for_each(p, &up->pid_handlers) {
             if (p->pid == pid) {
                 list_del(p);
                 qe_free(&p);
@@ -123,7 +143,7 @@ int set_pid_handler(int pid,
         p->pid = pid;
         p->cb = cb;
         p->opaque = opaque;
-        list_add(p, &pid_handlers);
+        list_add(p, &up->pid_handlers);
     }
     return 0;
 }
@@ -131,25 +151,28 @@ int set_pid_handler(int pid,
 /*
  * add an explicit call back to avoid recursions
  */
-void register_bottom_half(void (*cb)(void *opaque), void *opaque)
+int url_register_bottom_half(URLState *up, void (*cb)(void *opaque), void *opaque)
 {
     BottomHalfEntry *bh;
 
     /* Should not fail */
     bh = qe_mallocz(BottomHalfEntry);
+    if (!bh)
+        return -1;
     bh->cb = cb;
     bh->opaque = opaque;
-    list_add(bh, &bottom_halves);
+    list_add(bh, &up->bottom_halves);
+    return 0;
 }
 
 /*
  * remove bottom half
  */
-void unregister_bottom_half(void (*cb)(void *opaque), void *opaque)
+void url_unregister_bottom_half(URLState *up, void (*cb)(void *opaque), void *opaque)
 {
     BottomHalfEntry *bh, *bh1;
 
-    list_for_each_safe(bh, bh1, &bottom_halves) {
+    list_for_each_safe(bh, bh1, &up->bottom_halves) {
         if (bh->cb == cb && bh->opaque == opaque) {
             list_del(bh);
             qe_free(&bh);
@@ -157,28 +180,28 @@ void unregister_bottom_half(void (*cb)(void *opaque), void *opaque)
     }
 }
 
-QETimer *qe_add_timer(int delay, void *opaque, void (*cb)(void *opaque))
+URLTimer *url_add_timer(URLState *up, int delay, void *opaque, void (*cb)(void *opaque))
 {
-    QETimer *ti;
+    URLTimer *ti;
 
-    ti = qe_mallocz(QETimer);
+    ti = qe_mallocz(URLTimer);
     if (!ti)
         return NULL;
     ti->timeout = get_clock_ms() + delay;
     ti->opaque = opaque;
     ti->cb = cb;
-    ti->next = first_timer;
-    first_timer = ti;
+    ti->next = up->first_timer;
+    up->first_timer = ti;
     return ti;
 }
 
-void qe_kill_timer(QETimer **tip)
+void url_kill_timer(URLState *up, URLTimer **tip)
 {
     if (*tip) {
-        QETimer **pt;
+        URLTimer **pt;
 
         /* remove timer from list of active timers and free it */
-        for (pt = &first_timer; *pt != NULL; pt = &(*pt)->next) {
+        for (pt = &up->first_timer; *pt != NULL; pt = &(*pt)->next) {
             if (*pt == (*tip)) {
                 *pt = (*tip)->next;
                 qe_free(tip);
@@ -190,35 +213,36 @@ void qe_kill_timer(QETimer **tip)
     }
 }
 
+int url_set_tail_handler(URLState *up, void (*cb)(void *opaque), void *opaque)
+{
+    up->tail_cb = cb;
+    up->tail_opaque = opaque;
+    return 0;
+}
+
 /* execute stacked bottom halves */
-static void qe__call_bottom_halves(void)
+static inline void url_call_bottom_halves(URLState *up)
 {
     BottomHalfEntry *bh;
 
-    while (!list_empty(&bottom_halves)) {
-        bh = (BottomHalfEntry *)bottom_halves.prev;
+    while (!list_empty(&up->bottom_halves)) {
+        bh = (BottomHalfEntry *)up->bottom_halves.prev;
         list_del(bh);
         bh->cb(bh->opaque);
         qe_free(&bh);
     }
 }
 
-static inline void call_bottom_halves(void)
-{
-    if (!list_empty(&bottom_halves))
-        qe__call_bottom_halves();
-}
-
 /* call timer callbacks and compute maximum next call time to
    check_timers() */
-static inline int check_timers(int max_delay)
+static inline int url_check_timers(URLState *up, int max_delay)
 {
-    QETimer *ti, **pt;
+    URLTimer *ti, **pt;
     int timeout, cur_time;
 
     cur_time = get_clock_ms();
     timeout = cur_time + max_delay;
-    pt = &first_timer;
+    pt = &up->first_timer;
     for (;;) {
         ti = *pt;
         if (ti == NULL)
@@ -229,7 +253,7 @@ static inline int check_timers(int max_delay)
             /* warning: a new timer can be added in the callback */
             ti->cb(ti->opaque);
             qe_free(&ti);
-            call_bottom_halves();
+            url_call_bottom_halves(up);
         } else {
             if ((ti->timeout - timeout) < 0)
                 timeout = ti->timeout;
@@ -239,25 +263,17 @@ static inline int check_timers(int max_delay)
     return timeout - cur_time;
 }
 
-static void url_block_reset(void)
-{
-    FD_ZERO(&url_rfds);
-    FD_ZERO(&url_wfds);
-    url_fdmax = -1;
-    url_exit_request = 0;
-}
-
 #define MAX_DELAY 500  /* milliseconds */
 
 /* block until one event */
-static void url_block(void)
+static void url_block(URLState *up)
 {
-    URLHandler *uh;
+    IOHandler *uh;
     int ret, i, delay;
     fd_set rfds, wfds;
     struct timeval tv;
 
-    delay = check_timers(MAX_DELAY);
+    delay = url_check_timers(up, MAX_DELAY);
 #if 0
     {
         static int count;
@@ -268,9 +284,9 @@ static void url_block(void)
     tv.tv_sec = delay / 1000;
     tv.tv_usec = (delay % 1000) * 1000;
 
-    rfds = url_rfds;
-    wfds = url_wfds;
-    ret = select(url_fdmax + 1, &rfds, &wfds, NULL, &tv);
+    rfds = up->rfds;
+    wfds = up->wfds;
+    ret = select(up->nfds, &rfds, &wfds, NULL, &tv);
 
     /* call each handler */
     /* extra checks on callback function pointers because a callback
@@ -279,17 +295,23 @@ static void url_block(void)
      * with a huge compressed file while it decompresses.
      * XXX: should break from the loop if callback changed the
      *      structures but need further investigation.
+     * Here is an example of a problem: if a callback closes a resource
+     * and opens another one that happens to get the same unix handle hd,
+     * the state of FD_ISSET(hd) will refer to the original resource and
+     * may erroneously call the new handler on a blocking event.
+     * Similarly, if a callback consumes a resource for a different handle
+     * the FD_ISSET will also be incorrect.
      */
     if (ret > 0) {
-        uh = url_handlers;
-        for (i = 0;i <= url_fdmax; i++) {
+        uh = up->handlers;
+        for (i = 0; i < up->nfds; i++) {
             if (FD_ISSET(i, &rfds) && uh->read_cb) {
                 uh->read_cb(uh->read_opaque);
-                call_bottom_halves();
+                url_call_bottom_halves(up);
             }
             if (FD_ISSET(i, &wfds) && uh->write_cb) {
                 uh->write_cb(uh->write_opaque);
-                call_bottom_halves();
+                url_call_bottom_halves(up);
             }
             uh++;
         }
@@ -301,15 +323,15 @@ static void url_block(void)
         int pid, status;
         PidHandler *ph, *ph1;
 
-        if (list_empty(&pid_handlers))
+        if (list_empty(&up->pid_handlers))
             break;
         pid = waitpid(-1, &status, WNOHANG);
         if (pid <= 0)
             break;
-        list_for_each_safe(ph, ph1, &pid_handlers) {
+        list_for_each_safe(ph, ph1, &up->pid_handlers) {
             if (ph->pid == pid && ph->cb) {
                 ph->cb(ph->opaque, status);
-                call_bottom_halves();
+                url_call_bottom_halves(up);
                 break;
             }
         }
@@ -317,39 +339,26 @@ static void url_block(void)
 #endif
 }
 
-int url_main_loop(int (*init)(void *opaque), void *opaque)
+int url_main_loop(URLState *up)
 {
-    QEArgs *ap = opaque;
-    url_block_reset();
-    if ((*init)(opaque))
-        return 1;
-    for (;;) {
-        if (url_exit_request)
-            break;
-        url_block();
-        if (url_display_request) {
-            QEmacsState *qs = ap->qs;
-
-            //qs->complete_refresh = 1;
-            do_refresh(qs->first_window);
-            qe_display(qs);
-            url_display_request = 0;
+    while (!up->exit_request) {
+        url_block(up);
+        if (*up->tail_cb) {
+            // call one shot tail function
+            void (*cb)(void *opaque) = up->tail_cb;
+            up->tail_cb = NULL;
+            (*cb)(up->tail_opaque);
+            url_call_bottom_halves(up);
         }
     }
+    up->exit_request = 0;
     return 0;
 }
 
 /* exit from url loop */
-void url_exit(void)
+void url_exit(URLState *up)
 {
-    url_exit_request = 1;
-}
-
-/* asynchronous redisplay signal received */
-void url_redisplay(QEditScreen *s)
-{
-    url_display_request = 1;
-    s->qs->complete_refresh = 1;
+    up->exit_request = 1;
 }
 
 int get_clock_ms(void) {

--- a/x11.c
+++ b/x11.c
@@ -397,7 +397,7 @@ static int x11_dpy_init(QEditScreen *s, QEmacsState *qs, int w, int h)
     xv_init(s);
 #endif
     fd = ConnectionNumber(xs->display);
-    set_read_handler(fd, x11_handle_event, s);
+    url_set_read_handler(qs->up, fd, x11_handle_event, s);
     return 0;
 }
 


### PR DESCRIPTION
* group urlio data into an `URLState` structure
* allocate `URLState` in `url_init()` and store it into the `QEmacsState`
* pass the `URLState` pointer to all `url_xxx` APIs
* add `tail_cb` for redisplay requests
* remove global variables
* simplify `qe_init()` call sequence
* add `QE_LIST_INIT` to initialize a linux doubly linked list