### PR TITLE
Fix display bug when killing active shell buffer

### DIFF
--- a/qe.c
+++ b/qe.c
@@ -5994,7 +5994,7 @@ static void parse_arguments(ExecCmdState *es)
 
     elapsed_time = get_clock_ms() - qs->cmd_start_time;
     qs->cmd_start_time += elapsed_time;
-    if (elapsed_time >= 100)
+    if (s && elapsed_time >= 100)
         put_status(s, "|%s: %dms", d->name, elapsed_time);
 
     qs->last_cmd_func = qs->this_cmd_func;


### PR DESCRIPTION
* add sanity check in `parse_arguments` to avoid printing to `stderr` if `s` has been deleted by command. Any command exiting the minibuffer causes it to be deleted, hence `qe_check_window(qs, &s)` clears `s`.  This caused a bug when killing an active shell buffer from bufed.