### PR TITLE
Improve directory handling

### DIFF
--- a/cutils.c
+++ b/cutils.c
@@ -157,23 +157,87 @@ int strend(const char *str, const char *val, const char **ptr) {
     }
 }
 
+size_t get_path_offset(const char *url) {
+    /*@API utils.string
+       Get the offset of the path component of a URL.
+       Return the offset to the first character of the path
+       part of the URL pointed to by string argument `url`.
+       The following parts are skipped if present:
+       - a protocol name or drive specifier
+       - a server name specified as //server_name/
+       - the root directory '/'
+     */
+    int i = 0, j;
+    unsigned char c;
+
+    if (url) {
+        // skip drive or protocol prefix (C:, https:...)
+        for (j = 0; j < 6; j++) {
+            c = url[j];
+            if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z')) {
+                if (j && c == ':')
+                    i = j + 1;
+                break;
+            }
+        }
+        // skip server name
+        if (url[i] == '/' && url[i + 1] == '/') {
+            i += 2;
+            while (url[i] && url[i] != '/')
+                i++;
+        }
+        // skip root directory
+#ifdef CONFIG_WIN32
+        if (url[i] == '/' || url[i] == '\\')
+            i++;
+#else
+        if (url[i] == '/')
+            i++;
+#endif
+    }
+    return i;
+}
+
+size_t get_parent_offset(const char *path, size_t base) {
+    /*@API utils.string
+       Get the offset of the parent component of a path for a given base.
+       Return the offset to the first character of the parent directory
+       part of the path pointed to by string argument `path` where `base`
+       is the offset of the basename.
+     */
+    size_t i, parent = get_path_offset(path);
+
+    if (path) {
+        for (i = parent; i + 1 < base && path[i]; i++) {
+#ifdef CONFIG_WIN32
+            /* Simplistic DOS/Windows filename support */
+            if (path[i] == '/' || path[i] == '\\')
+                parent = i + 1;
+#else
+            if (path[i] == '/')
+                parent = i + 1;
+#endif
+        }
+    }
+    return parent;
+}
+
 size_t get_basename_offset(const char *path) {
     /*@API utils.string
        Get the offset of the filename component of a path.
        Return the offset to the first character of the filename part of
        the path pointed to by string argument `path`.
      */
-    size_t i, base = 0;
-    const char *p = path;
+    size_t i, base = get_path_offset(path);
 
-    if (p) {
-        for (i = 0; p[i]; i++) {
+    if (path) {
+        for (i = base; path[i]; i++) {
 #ifdef CONFIG_WIN32
             /* Simplistic DOS/Windows filename support */
-            if (p[i] == '/' || p[i] == '\\' || (p[i] == ':' && i == 1))
+            if (path[i] == '/' || path[i] == '\\')
                 base = i + 1;
 #else
-            if (p[i] == '/')
+            if (path[i] == '/')
                 base = i + 1;
 #endif
         }

--- a/cutils.h
+++ b/cutils.h
@@ -152,6 +152,8 @@ static inline int strequal(const char *s1, const char *s2) {
 #define blockcpy(p1, p2, n)   memcpy(p1, p2, (n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
 #define blockmove(p1, p2, n) memmove(p1, p2, (n) * sizeof *(p1) / (sizeof *(p1) == sizeof *(p2)))
 
+size_t get_path_offset(const char *url);
+size_t get_parent_offset(const char *path, size_t base);
 size_t get_basename_offset(const char *filename);
 
 static inline const char *get_basename(const char *filename) {

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -1684,11 +1684,11 @@ static char *dired_get_default_path(EditBuffer *b, int offset,
         } else {
             get_dirname(buf, buf_size, b->filename);
         }
-        append_slash(buf, buf_size);
-        return buf;
     } else {
-        return getcwd(buf, buf_size) ? buf : NULL;
+        get_curdir(buf, buf_size);
     }
+    append_slash(buf, buf_size);
+    return buf;
 }
 
 static int dired_mode_init(EditState *s, EditBuffer *b, int flags)

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -2829,8 +2829,7 @@ EditBuffer *qe_new_shell_buffer(QEmacsState *qs, EditBuffer *b0, EditState *e,
     if (e) {
         get_default_path(e->b, e->offset, curpath, countof(curpath));
     } else {
-        *curpath = '\0';
-        getcwd(curpath, countof(curpath));
+        get_curdir(curpath, countof(curpath));
     }
     append_slash(curpath, countof(curpath));
     shell_add_cwd(b, 0, curpath, 1);

--- a/qe-manual.md
+++ b/qe-manual.md
@@ -1386,6 +1386,23 @@ If there is no extension, return a pointer to the null terminator
 and the end of path.
 Leading dots are skipped, they are not considered part of an extension.
 
+### `size_t get_parent_offset(const char *path, size_t base);`
+
+Get the offset of the parent component of a path for a given base.
+Return the offset to the first character of the parent directory
+part of the path pointed to by string argument `path` where `base`
+is the offset of the basename.
+
+### `size_t get_path_offset(const char *url);`
+
+Get the offset of the path component of a URL.
+Return the offset to the first character of the path
+part of the URL pointed to by string argument `url`.
+The following parts are skipped if present:
+- a protocol name or drive specifier
+- a server name specified as //server_name/
+- the root directory '/'
+
 ### `const char *get_relativename(const char *filename, const char *dirname);`
 
 Get the offset to the filename porting that is relative to the

--- a/qe.c
+++ b/qe.c
@@ -9115,41 +9115,24 @@ void canonicalize_absolute_buffer_path(EditBuffer *b, int offset, char *buf, int
 {
     char cwd[MAX_FILENAME_SIZE];
     char path[MAX_FILENAME_SIZE];
-    char *homedir;
 
     if (!is_abs_path(path1)) {
         if (*path1 == '~') {
-            if (path1[1] == '\0' || path1[1] == '/') {
-                homedir = getenv("HOME");
-                if (homedir) {
-                    pstrcpy(path, sizeof(path), homedir);
-#ifdef CONFIG_WIN32
-                    path_win_to_unix(path);
-#endif
-                    remove_slash(path);
-                    pstrcat(path, sizeof(path), path1 + 1);
-                    path1 = path;
-                }
-            } else {
-                /* CG: should get info from getpwnam */
-#ifdef CONFIG_DARWIN
-                pstrcpy(path, sizeof(path), "/Users/");
-#else
-                pstrcpy(path, sizeof(path), "/home/");
-#endif
-                pstrcat(path, sizeof(path), path1 + 1);
+            char login[64];
+            const char *tail = path1 + strcspn(path1, "/");
+            pstrncpy(login, countof(login), path1 + 1, tail - (path1 + 1));
+            if (get_homedir(path, countof(path), login)) {
+                remove_slash(path);
+                pstrcat(path, countof(path), tail);
                 path1 = path;
             }
         } else {
-            /* CG: not sufficient for windows drives */
-            if (!b || !get_default_path(b, offset, cwd, sizeof(cwd))) {
-                if (!getcwd(cwd, sizeof(cwd)))
-                    strcpy(cwd, ".");
-#ifdef CONFIG_WIN32
-                path_win_to_unix(cwd);
-#endif
+            if (b) {
+                get_default_path(b, offset, cwd, countof(cwd));
+            } else {
+                get_curdir(cwd, countof(cwd));
             }
-            makepath(path, sizeof(path), cwd, path1);
+            makepath(path, countof(path), cwd, path1);
             path1 = path;
         }
     }
@@ -9160,7 +9143,7 @@ void canonicalize_absolute_buffer_path(EditBuffer *b, int offset, char *buf, int
 char *get_default_path(EditBuffer *b, int offset, char *buf, int buf_size)
 {
     char buf1[MAX_FILENAME_SIZE];
-    const char *filename;
+    const char *filename = "a";
 
     /* dispatch to mode specific handler if any */
     if (b->default_mode
@@ -9168,15 +9151,13 @@ char *get_default_path(EditBuffer *b, int offset, char *buf, int buf_size)
     &&  b->default_mode->get_default_path(b, offset, buf, buf_size)) {
         return buf;
     }
-
-    if ((b->flags & BF_SYSTEM)
-    ||  b->name[0] == '*'
-    ||  b->filename[0] == '\0') {
-        filename = "a";
-    } else {
+    if (b->filename[0]) {
         filename = b->filename;
     }
-    /* XXX: should just retrieve the current directory */
+    // XXX: should just retrieve the current directory?
+    // XXX: fix this mess: canonicalize_absolute_path calls
+    //canonicalize_absolute_buffer_path(NULL, 0, buf1, sizeof(buf1), filename);
+    // which in turn calls get_default_path if `b` is not NULL
     canonicalize_absolute_path(NULL, buf1, sizeof(buf1), filename);
     splitpath(buf, buf_size, NULL, 0, buf1);
     return buf;
@@ -11632,7 +11613,6 @@ void do_add_resource_path(EditState *s, const char *path)
 static void qe_set_user_option(QEmacsState *qs, const char *user)
 {
     char path[MAX_FILENAME_SIZE];
-    const char *home_path;
 
     qs->user_option = user;
 
@@ -11641,30 +11621,19 @@ static void qe_set_user_option(QEmacsState *qs, const char *user)
 
     /* put current directory first if qe invoked as ./qe */
     if (stristart(qs->argv[0], "./qe", NULL)) {
-        if (!getcwd(path, sizeof(path)))
-            strcpy(path, ".");
+        get_curdir(path, sizeof(path));
         pstrcat(qs->res_path, sizeof(qs->res_path), path);
         pstrcat(qs->res_path, sizeof(qs->res_path), ":");
+        append_slash(path, countof(path));
         pstrcat(qs->res_path, sizeof(qs->res_path), path);
-        pstrcat(qs->res_path, sizeof(qs->res_path), "/unidata:");
+        pstrcat(qs->res_path, sizeof(qs->res_path), "unidata:");
     }
 
     /* put user directory before standard list */
-    if (user) {
-        /* use ~USER/.qe instead of ~/.qe */
-        /* CG: should get user homedir */
-#ifdef CONFIG_DARWIN
-        snprintf(path, sizeof(path), "/Users/%s", user);
-#else
-        snprintf(path, sizeof(path), "/home/%s", user);
-#endif
-        home_path = path;
-    } else {
-        home_path = getenv("HOME");
-    }
-    if (home_path) {
-        pstrcat(qs->res_path, sizeof(qs->res_path), home_path);
-        pstrcat(qs->res_path, sizeof(qs->res_path), "/.qe:");
+    if (get_homedir(path, countof(path), user)) {
+        append_slash(path, countof(path));
+        pstrcat(qs->res_path, sizeof(qs->res_path), path);
+        pstrcat(qs->res_path, sizeof(qs->res_path), ".qe:");
     }
 
     pstrcat(qs->res_path, sizeof(qs->res_path),

--- a/util.c
+++ b/util.c
@@ -31,6 +31,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <unistd.h>
 
 #include "config.h"     /* for CONFIG_WIN32 */
 #include "util.h"
@@ -253,6 +256,40 @@ int is_filepattern(const char *filespec) {
     return filespec[pos] != '\0';
 }
 
+char *get_curdir(char *dest, size_t size) {
+    if (!getcwd(dest, size))
+        pstrcpy(dest, size, ".");
+#ifdef CONFIG_WIN32
+    path_win_to_unix(dest);
+#endif
+    return dest;
+}
+
+char *get_homedir(char *dest, size_t size, const char *login) {
+    const char *homedir = NULL;
+
+    if (login && *login) {
+        struct passwd *pw = getpwnam(login);
+        if (pw)
+            homedir = pw->pw_dir;
+    } else {
+        homedir = getenv("HOME");
+        if (!homedir) {
+            struct passwd *pw = getpwent();
+            if (pw)
+                homedir = pw->pw_dir;
+        }
+    }
+    if (homedir) {
+        pstrcpy(dest, size, homedir);
+#ifdef CONFIG_WIN32
+        path_win_to_unix(dest);
+#endif
+        return dest;
+    }
+    return NULL;
+}
+
 static void canonicalize_path1(char *buf, int buf_size, const char *path) {
     /* XXX: make it better */
     const char *p;
@@ -359,6 +396,7 @@ char *canonicalize_path(char *buf, int buf_size, const char *path) {
 }
 
 char *make_user_path(char *buf, int buf_size, const char *path) {
+    char homedir[MAX_FILENAME_SIZE];
     /*@API utils
        Reduce a path relative to the user's homedir, using the `~`
        shell syntax.
@@ -369,22 +407,15 @@ char *make_user_path(char *buf, int buf_size, const char *path) {
        @note this function uses the `HOME` environment variable to
        determine the user's home directory
      */
-    char *homedir = getenv("HOME");
-    if (homedir) {
-        int len = strlen(homedir);
-
-        if (len && homedir[len - 1] == '/')
-            len--;
-
-        if (!memcmp(path, homedir, len) && (path[len] == '/' || path[len] == '\0')) {
-            if (buf_size > 1) {
+    if (get_homedir(homedir, countof(homedir), NULL)) {
+        if (homedir[0] && homedir[1] && buf_size > 1) {
+            const char *tail;
+            remove_slash(homedir);
+            if (strstart(path, homedir, &tail) && (*tail == '/' || *tail == '\0')) {
                 *buf = '~';
-                pstrcpy(buf + 1, buf_size - 1, path + len);
-            } else {
-                if (buf_size > 0)
-                    *buf = '\0';
+                pstrcpy(buf + 1, buf_size - 1, tail);
+                return buf;
             }
-            return buf;
         }
     }
     return pstrcpy(buf, buf_size, path);
@@ -607,7 +638,6 @@ int remove_slash(char *buf) {
        Remove the trailing slash from path, except for / directory.
        @return the updated path length.
      */
-    // XXX: should we have windows specific behavior?
     // XXX: should we handle protocol prefixes specifically?
     int len = strlen(buf);
     if (len > 1 && buf[len - 1] == '/') {
@@ -622,7 +652,6 @@ int append_slash(char *buf, int buf_size) {
        @return the updated path length.
        @note: truncation cannot be detected reliably
      */
-    // XXX: should we have windows specific behavior?
     int len = strnlen(buf, buf_size);
     if (len > 0 && buf[len - 1] != '/' && len + 1 < buf_size) {
         buf[len++] = '/';

--- a/util.h
+++ b/util.h
@@ -62,6 +62,8 @@ void find_file_close(FindFileState **sp);
 int qe_shell_match(const char *pattern, const char *string);
 int is_directory(const char *path);
 int is_filepattern(const char *filespec);
+char *get_curdir(char *dest, size_t size);
+char *get_homedir(char *dest, size_t size, const char *login);
 char *canonicalize_path(char *buf, int buf_size, const char *path);
 char *make_user_path(char *buf, int buf_size, const char *path);
 char *reduce_filename(char *dest, int size, const char *filename);


### PR DESCRIPTION
* add `get_path_offset` to skip drive/protocol, serveur name and root dir.
* add `get_parent_offset` to get the parent of path component
* add `get_curdir` to hide OS dependencies and test `getcwd` failures
* add `get_homedir` for current or specified user
* simplify `make_user_path`, `canonicalize_absolute_buffer_path`, `qe_set_user_option`