### PR TITLE
minibuf: resolve bindings redefinition

### DIFF
--- a/qe.c
+++ b/qe.c
@@ -8584,18 +8584,18 @@ static const CmdDef minibuffer_commands[] = {
           "Yank from kill buffer with side effects",
           do_minibuffer_electric_yank, ES, "*")
     /* commands used to configure search flags */
-    CMD0( "minibuffer-toggle-case-fold", "M-c, C-c",
+    CMD0( "minibuffer-toggle-case-fold", "",
           "toggle search case-sensitivity",
           isearch_toggle_case_fold)
-    CMD0( "minibuffer-toggle-hex", "M-h, M-C-b",
+    CMD0( "minibuffer-toggle-hex", "",
           "toggle normal/hex/unihex searching",
           isearch_toggle_hex)
 #ifdef CONFIG_REGEX
-    CMD0( "minibuffer-toggle-regexp", "M-r, C-t",
+    CMD0( "minibuffer-toggle-regexp", "",
           "toggle regular-expression mode",
           isearch_toggle_regexp)
 #endif
-    CMD0( "minibuffer-toggle-word-match", "M-w",
+    CMD0( "minibuffer-toggle-word-match", "",
           "toggle word match",
           isearch_toggle_word_match)
 };

--- a/search.c
+++ b/search.c
@@ -1474,11 +1474,32 @@ void do_search_string(EditState *s, const char *search_str, int mode)
     }
 }
 
+static void minibuffer_search_bindings(EditState *s, int enable)
+{
+    /* bindings used to configure search flags */
+    if (enable) {
+        do_set_key(s, "M-c, C-c", "minibuffer-toggle-case-fold", 1);
+        do_set_key(s, "M-h, M-C-b", "minibuffer-toggle-hex", 1);
+        do_set_key(s, "M-w", "minibuffer-toggle-word-match", 1);
+#ifdef CONFIG_REGEX
+        do_set_key(s, "M-r, C-t", "minibuffer-toggle-regexp", 1);
+#endif
+    } else {
+        do_unset_key(s, "M-c, C-c", 1);
+        do_unset_key(s, "M-h, M-C-b", 1);
+        do_unset_key(s, "M-w", 1);
+#ifdef CONFIG_REGEX
+        do_unset_key(s, "M-r, C-t", 1);
+#endif
+    }
+}
+
 static void minibuffer_search_start_edit(EditState *s) {
     ISearchState *is = set_search_state(s->target_window, 1, 1);
     if (is != NULL) {
         is->minibuffer = s;
         isearch_cycle_flags(s, 0);
+        minibuffer_search_bindings(s, 1);
     }
 }
 
@@ -1489,6 +1510,7 @@ static void minibuffer_search_end_edit(EditState *s, char *dest, int size) {
         s1->isearch_state->minibuffer = NULL;
         s1->isearch_state = NULL;
         // XXX: should free the ISearchState structure
+        minibuffer_search_bindings(s, 0);
     }
 }
 


### PR DESCRIPTION
* enable search bindings on `search_completion` entry and disable them
  on exit.