### PR TITLE
Mouse: fix bug on a single click

### DIFF
--- a/qe.c
+++ b/qe.c
@@ -1548,6 +1548,7 @@ void perform_scroll_up_down(EditState *s, int h)
     display1(ds);
     display_close(ds);
 
+    s->qs->mouse_clicks = 0;
     s->offset = m->offset_found;
 }
 


### PR DESCRIPTION
* reset the number of mouse clicks to zero after scrolling to prevent unintentional entire buffer marking.

This fixes a bug when single-clicking to stop scrolling