### PR TITLE
Startup: fix crash bug on `set_style()` from the config file

### DIFF
--- a/cfb.c
+++ b/cfb.c
@@ -312,7 +312,7 @@ static void cfb_draw_text(QEditScreen *s, QEFont *font,
         int y1 = y_base + font->descent;
         int w = x1 - x0;
         int h = y1 - y0;
-        int dh = max_int((font->descent + 2) / 4, 1);
+        int dh = max_int(1, (font->descent + 2) / 4);
         int dw = dh;    // assume 1.0 aspect ratio
         if (font->style & QE_FONT_STYLE_UNDERLINE) {
             int y = y_base + (font->descent + 1) / 3;

--- a/display.c
+++ b/display.c
@@ -32,8 +32,11 @@ static QEDisplay *first_dpy;
 static int dummy_dpy_init(QEditScreen *s, QEmacsState *qs, qe__unused__ int w, qe__unused__ int h)
 {
     s->qs = qs;
-    s->charset = &charset_8859_1;
-
+    s->priv_data = NULL;
+    s->media = CSS_MEDIA_TTY;
+    s->charset = &charset_utf8;
+    s->width = 132;
+    s->height = 50;
     return 0;
 }
 
@@ -272,6 +275,7 @@ QEDisplay *probe_display(void)
 
 int qe_screen_init(QEmacsState *qs, QEditScreen *s, QEDisplay *dpy, int w, int h)
 {
+    free_font_cache(s);
     s->dpy = dpy ? *dpy : dummy_dpy;
     return s->dpy.dpy_init(s, qs, w, h);
 }
@@ -344,6 +348,7 @@ QEFont *select_font(QEditScreen *s, int style, int size)
     /* select_font never returns NULL */
     /* CG: This is bogus, dummy font is not device compatible? */
     fc = &dummy_font;
+    fc->descent = 1;
     fc->system_font = 1;
     return fc;
 }

--- a/haiku.cpp
+++ b/haiku.cpp
@@ -777,7 +777,7 @@ static void haiku_draw_text(QEditScreen *s, QEFont *font,
         BFont *f = (BFont *)font->priv_data;
         int x1 = x0 + (int)f->StringWidth(text.String()) - 1;
         int y1 = y_base + font->descent;
-        int dh = max_int((font->descent + 2) / 4, 1);
+        int dh = max_int(1, (font->descent + 2) / 4);
         int dw = dh;    // assume 1.0 aspect ratio
         if (font->style & QE_FONT_STYLE_UNDERLINE) {
             int y = y_base + (font->descent + 1) / 3;

--- a/qe.c
+++ b/qe.c
@@ -10010,23 +10010,21 @@ void do_refresh(EditState *s1)
     if (qs->screen->media & CSS_MEDIA_TTY) {
         qs->separator_width = 1;
         qs->border_width = 1;
+        new_status_height = 1;
+        new_mode_line_height = 1;
     } else {
         qs->separator_width = 4;
         qs->border_width = 4; /* XXX: adapt to display type */
+        /* Prevent potential division overflow */
+        new_status_height = max_int(1, get_line_height(qs->screen, NULL, QE_STYLE_STATUS));
+        new_mode_line_height = max_int(1, get_line_height(qs->screen, NULL, QE_STYLE_MODE_LINE));
     }
 
     width = qs->screen->width;
     height = qs->screen->height;
-    new_status_height = get_line_height(qs->screen, NULL, QE_STYLE_STATUS);
-    new_mode_line_height = get_line_height(qs->screen, NULL, QE_STYLE_MODE_LINE);
     content_height = height;
     if (!qs->hide_status)
         content_height -= new_status_height;
-
-    /* Prevent potential division overflow */
-    width = max_int(1, width);
-    height = max_int(1, height);
-    content_height = max_int(1, content_height);
 
     resized = 0;
 

--- a/x11.c
+++ b/x11.c
@@ -245,8 +245,8 @@ static int x11_dpy_init(QEditScreen *s, QEmacsState *qs, int w, int h)
         fprintf(stderr, "Could not open default font\n");
         exit(1);
     }
-    font_ysize = max_int(font->ascent + font->descent, 1);
-    font_xsize = max_int(glyph_width(s, font, 'x'), 1);
+    font_ysize = max_int(1, font->ascent + font->descent);
+    font_xsize = max_int(1, glyph_width(s, font, 'x'));
     x11_dpy_close_font(s, &font);
 
     if (w > 0 && h > 0) {
@@ -1035,7 +1035,7 @@ static void x11_dpy_draw_text(QEditScreen *s, QEFont *font,
         int y1 = y_base + font->descent;
         int w = x1 - x0;
         int h = y1 - y0;
-        int dh = max_int((font->descent + 2) / 4, 1);
+        int dh = max_int(1, (font->descent + 2) / 4);
         int dw = dh;    // assume 1.0 aspect ratio
         if (font->style & QE_FONT_STYLE_UNDERLINE) {
             int y = y_base + (font->descent + 1) / 3;


### PR DESCRIPTION
* fix crash bug on Linux when `set_style` is called from the config file for the `"default"` style.
* the `dummy_dpy` was not intialized properly, causing a division by zero error reported as `Program received signal SIGFPE, Arithmetic exception.`
* this bug was harmless on Apple M1 and later processors because zero division does not cause an exception on such hardware.
* fixes #207