### PR TITLE
completion: fix handling of empty and relative paths

### DIFF
--- a/modes/shell.c
+++ b/modes/shell.c
@@ -4498,8 +4498,8 @@ static void shellcmd_complete(CompleteState *cp, CompleteFunc enumerate)
         splitpath(path, sizeof(path), file, sizeof(file), start);
 
         pstrcpy(buf, sizeof(buf), path);
-        if (buf[0] == '~')
-            canonicalize_absolute_path(cp->s, buf, sizeof(buf), path);
+        if (*buf == '\0' || !is_abs_path(buf))
+            canonicalize_absolute_path(cp->target, buf, sizeof(buf), path);
         path1 = *buf ? buf : ".";
     }
     pstrcat(file, sizeof(file), "*");

--- a/qe.c
+++ b/qe.c
@@ -7736,8 +7736,8 @@ void file_complete(CompleteState *cp, CompleteFunc enumerate)
     int len;
 
     current = cp->current;
-    if (*current == '~') {
-        canonicalize_absolute_path(cp->s, filename, sizeof(filename), cp->current);
+    if (*current == '\0' || !is_abs_path(current)) {
+        canonicalize_absolute_path(cp->target, filename, sizeof(filename), cp->current);
         current = filename;
     }
 


### PR DESCRIPTION
* resolve empty and relative paths using target window's directory before falling back to the editor's global `CWD`.