### PR TITLE
buffer: add auto formatting options on save

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -732,6 +732,12 @@ EditBuffer *qe_new_buffer(QEmacsState *qs, const char *name, int flags)
     b->eol_type = qs->default_eol_type;
     b->atime = b->mtime = b->ctime = get_clock_ms();
 
+#ifndef CONFIG_TINY
+    b->require_final_newline = qs->default_require_final_newline;
+    b->delete_trailing_whitespace = qs->default_delete_trailing_whitespace;
+    b->untabify = qs->default_untabify;
+#endif
+
     /* set the buffer name to a unique name */
     // XXX: `b` is not in the buffer list nor in the buffer cache
     //      `eb_set_buffer_name` will insert it into the cache.

--- a/extras.c
+++ b/extras.c
@@ -712,7 +712,7 @@ static void do_tabify_region(EditState *s)
     eb_tabify(s->b, s->b->mark, s->offset);
 }
 #endif
-static void do_untabify(EditState *s, int p1, int p2)
+void do_untabify(EditState *s, int p1, int p2)
 {
     /* We implement a complete analysis of the region instead of
      * potentially faster scan for '\t'.  It is fast enough and even

--- a/lang/makemode.c
+++ b/lang/makemode.c
@@ -37,6 +37,8 @@ enum {
     MAKEFILE_STYLE_MACRO      = QE_STYLE_TYPE,
 };
 
+static ModeDef makefile_mode;
+
 static void makefile_colorize_line(QEColorizeContext *cp,
                                    const char32_t *str, int n,
                                    QETermStyle *sbuf, ModeDef *syn)
@@ -139,9 +141,12 @@ static void makefile_colorize_line(QEColorizeContext *cp,
 static int makefile_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
-        /* XXX: should use the default values from mode variables */
-        s->b->tab_width = 8;
         s->indent_tabs_mode = 1;
+    }
+    if (b) {
+        /* XXX: should use the default values from mode variables */
+        b->tab_width = 8;
+        b->untabify = 0;
     }
     return 0;
 }

--- a/lang/python.c
+++ b/lang/python.c
@@ -351,6 +351,8 @@ static ModeDef rapydscript_mode = {
 
 /*---- Bazel mode: a build system with a Python-like syntax ----*/
 
+static ModeDef bazel_mode;
+
 static int bazel_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {

--- a/modes/dired.c
+++ b/modes/dired.c
@@ -2147,8 +2147,7 @@ void do_filelist(EditState *s, int argval)
 static int filelist_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_TRUNCATE;
+        s->wrap = filelist_mode.default_wrap;
     }
     return 0;
 }
@@ -2181,6 +2180,7 @@ static int filelist_init(QEmacsState *qs)
     filelist_mode.mode_probe = NULL;
     filelist_mode.mode_init = filelist_mode_init;
     filelist_mode.display_hook = filelist_display_hook;
+    filelist_mode.default_wrap = WRAP_TRUNCATE;
 
     qe_register_mode(qs, &filelist_mode, MODEF_VIEW);
     qe_register_commands(qs, &filelist_mode, filelist_commands, countof(filelist_commands));

--- a/modes/hex.c
+++ b/modes/hex.c
@@ -30,7 +30,7 @@ enum {
     HEX_STYLE_DUMP   = QE_STYLE_FUNCTION,
 };
 
-static ModeDef hex_mode;
+static ModeDef hex_mode, binary_mode;
 
 static int bin_to_disp(int c)
 {
@@ -181,8 +181,14 @@ static int binary_mode_init(EditState *s, EditBuffer *b, int flags)
         s->hex_mode = 0;
         s->unihex_mode = 0;
         s->overwrite = 1;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_TRUNCATE;
+        s->wrap = binary_mode.default_wrap;
+    }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->untabify = 0;
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+#endif
     }
     return 0;
 }
@@ -195,8 +201,14 @@ static int hex_mode_init(EditState *s, EditBuffer *b, int flags)
         s->hex_nibble = 0;
         s->unihex_mode = 0;
         s->overwrite = 1;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_TRUNCATE;
+        s->wrap = hex_mode.default_wrap;
+    }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->untabify = 0;
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+#endif
     }
     return 0;
 }
@@ -366,12 +378,12 @@ static ModeDef hex_mode = {
 
 static int hex_init(QEmacsState *qs)
 {
-    /* first register mode(s) */
+    binary_mode.default_wrap = WRAP_TRUNCATE;
     qe_register_mode(qs, &binary_mode, MODEF_VIEW);
-    qe_register_mode(qs, &hex_mode, MODEF_VIEW);
-
-    /* commands and default keys */
     qe_register_commands(qs, &binary_mode, binary_commands, countof(binary_commands));
+
+    hex_mode.default_wrap = WRAP_TRUNCATE;
+    qe_register_mode(qs, &hex_mode, MODEF_VIEW);
     qe_register_commands(qs, &hex_mode, hex_commands, countof(hex_commands));
 
     return 0;

--- a/modes/image.c
+++ b/modes/image.c
@@ -548,6 +548,13 @@ static int image_mode_init(EditState *s, EditBuffer *b, int flags)
 
         eb_add_callback(s->b, image_callback, s, 1);
     }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+        b->untabify = 0;
+#endif
+    }
     return 0;
 }
 

--- a/modes/markdown.c
+++ b/modes/markdown.c
@@ -24,7 +24,7 @@
 
 #include "qe.h"
 
-static ModeDef litcoffee_mode;
+static ModeDef litcoffee_mode, mkd_mode;
 
 enum {
     /* TODO: define specific styles */
@@ -896,10 +896,11 @@ static const CmdDef mkd_commands[] = {
 static int mkd_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
-        s->b->tab_width = 4;
         s->indent_tabs_mode = 0;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_WORD;
+        s->wrap = mkd_mode.default_wrap;
+    }
+    if (b) {
+        b->tab_width = 4;
     }
     return 0;
 }
@@ -922,11 +923,12 @@ static ModeDef mdx_mode = {
 static int litcoffee_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
-        s->b->tab_width = 4;
         s->indent_tabs_mode = 0;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_WORD;
+        s->wrap = litcoffee_mode.default_wrap;
         s->mode->colorize_flags = mkd_add_lang(s->qs, "coffee", 0);
+    }
+    if (b) {
+        b->tab_width = 4;
     }
     return 0;
 }
@@ -941,10 +943,13 @@ static ModeDef litcoffee_mode = {
 
 static int mkd_init(QEmacsState *qs)
 {
+    mkd_mode.default_wrap = WRAP_WORD;
     qe_register_mode(qs, &mkd_mode, MODEF_SYNTAX);
     qe_register_commands(qs, &mkd_mode, mkd_commands, countof(mkd_commands));
     qe_register_mode(qs, &mdx_mode, MODEF_SYNTAX);
     qe_register_commands(qs, &mdx_mode, mkd_commands, countof(mkd_commands));
+
+    litcoffee_mode.default_wrap = WRAP_WORD;
     qe_register_mode(qs, &litcoffee_mode, MODEF_SYNTAX);
     qe_register_commands(qs, &litcoffee_mode, mkd_commands, countof(mkd_commands));
 

--- a/modes/mpeg.c
+++ b/modes/mpeg.c
@@ -147,8 +147,14 @@ static int mpeg_mode_init(EditState *s, EditBuffer *b, int flags)
     if (s) {
         s->hex_mode = 1;
         s->hex_nibble = 0;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_TRUNCATE;
+        s->wrap = mpeg_mode.default_wrap;
+    }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+        b->untabify = 0;
+#endif
     }
     return 0;
 }
@@ -176,6 +182,7 @@ static ModeDef mpeg_mode = {
 
 static int mpeg_init(QEmacsState *qs)
 {
+    mpeg_mode.default_wrap = WRAP_TRUNCATE;
     qe_register_mode(qs, &mpeg_mode, MODEF_MAJOR | MODEF_VIEW);
     return 0;
 }

--- a/modes/shell.c
+++ b/modes/shell.c
@@ -4679,13 +4679,15 @@ static int shell_mode_init(EditState *e, EditBuffer *b, int flags)
         if (!(s = shell_get_state(e, 1)))
             return -1;
 
-        e->b->tab_width = 8;
-        e->wrap = WRAP_TERM;
+        e->wrap = shell_mode.default_wrap;
         e->wrap_cols = s->cols;
         if ((s->shell_flags & SF_INTERACTIVE) && !s->grab_keys) {
             e->interactive = 1;
             e->b->flags &= ~BF_READONLY;
         }
+    }
+    if (b) {
+        b->tab_width = 8;
     }
     return 0;
 }
@@ -4693,10 +4695,10 @@ static int shell_mode_init(EditState *e, EditBuffer *b, int flags)
 static int pager_mode_init(EditState *e, EditBuffer *b, int flags)
 {
     if (e) {
-        e->b->tab_width = 8;
         e->wrap = pager_mode.default_wrap;
     }
     if (b) {
+        b->tab_width = 8;
         b->modified = 0;
         b->flags |= BF_READONLY;
     }
@@ -4706,10 +4708,10 @@ static int pager_mode_init(EditState *e, EditBuffer *b, int flags)
 static int compilation_mode_init(EditState *e, EditBuffer *b, int flags)
 {
     if (e) {
-        e->b->tab_width = 8;
         e->wrap = compilation_mode.default_wrap;
     }
     if (b) {
+        b->tab_width = 8;
         b->modified = 0;
         b->flags |= BF_ERROR | BF_READONLY;
     }
@@ -4853,6 +4855,7 @@ static int shell_init(QEmacsState *qs)
     shell_mode.write_char = shell_write_char;
     shell_mode.delete_bytes = shell_delete_bytes;
     shell_mode.get_default_path = shell_get_default_path;
+    shell_mode.default_wrap = WRAP_TERM;
 
     qe_register_mode(qs, &shell_mode, MODEF_NOCMD | MODEF_VIEW);
     qe_register_commands(qs, &shell_mode, shell_commands, countof(shell_commands));

--- a/modes/unihex.c
+++ b/modes/unihex.c
@@ -30,6 +30,8 @@ enum {
     UNIHEX_STYLE_DUMP   = QE_STYLE_FUNCTION,
 };
 
+static ModeDef unihex_mode;
+
 static int unihex_mode_init(EditState *s, EditBuffer *b, int flags)
 {
     if (s) {
@@ -53,8 +55,14 @@ static int unihex_mode_init(EditState *s, EditBuffer *b, int flags)
         s->unihex_mode = w = snprintf(NULL, 0, "%x", maxc);
         s->dump_width = clamp_int((s->width - 8 - 2 - 2 - 1) / (w + 3), 8, 16);
         s->overwrite = 1;
-        /* XXX: should come from mode.default_wrap */
-        s->wrap = WRAP_TRUNCATE;
+        s->wrap = unihex_mode.default_wrap;
+    }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->untabify = 0;
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+#endif
     }
     return 0;
 }
@@ -267,6 +275,7 @@ static ModeDef unihex_mode = {
 };
 
 static int unihex_init(QEmacsState *qs) {
+    unihex_mode.default_wrap = WRAP_TRUNCATE;
     qe_register_mode(qs, &unihex_mode, MODEF_VIEW);
     return 0;
 }

--- a/modes/video.c
+++ b/modes/video.c
@@ -866,6 +866,13 @@ static int video_mode_init(EditState *s, EditBuffer *b, int flags)
         if (err != 0)
             return -1;
     }
+    if (b) {
+#ifndef CONFIG_TINY
+        b->require_final_newline = 0;
+        b->delete_trailing_whitespace = 0;
+        b->untabify = 0;
+#endif
+    }
     return 0;
 }
 

--- a/qe.c
+++ b/qe.c
@@ -9698,6 +9698,123 @@ static void put_save_message(EditState *s, const char *filename, int nb)
     }
 }
 
+#ifndef CONFIG_TINY
+enum {
+    SAVE_SCAN_EOF,
+    SAVE_SCAN_WHITESPACE,
+    SAVE_SCAN_TABS,
+    SAVE_SCAN_NONE,
+};
+
+typedef struct SaveContext {
+    int state;
+    EditState *s;
+} SaveContext;
+
+static void save_scan_next(SaveContext *save_ctx);
+
+static void save_scan_key(QEmacsState *qs, void *opaque, int key)
+{
+    SaveContext *save_ctx = opaque;
+    EditState *s = save_ctx->s;
+
+    switch (key) {
+    case KEY_CTRL('g'):
+        put_error(qs->active_window, "&Quit");
+        qe_free(&save_ctx);
+        qe_ungrab_keys(qs);
+        return;
+    case 'n':
+        break;
+    case 'y':
+        switch (save_ctx->state) {
+        case SAVE_SCAN_EOF:
+            eb_putc(s->b, '\n');
+            break;
+        case SAVE_SCAN_WHITESPACE:
+            do_delete_horizontal_space(s, 3); // DH_FULL
+            break;
+        case SAVE_SCAN_TABS:
+            do_untabify(s, 0, s->b->total_size);
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        dpy_sound_bell(s->screen);
+        return;
+    }
+    qe_display(qs);
+    qe_ungrab_keys(qs);
+
+    save_ctx->state++;
+    save_scan_next(save_ctx);
+}
+
+void save_scan_next(SaveContext *save_ctx)
+{
+    EditState *s = save_ctx->s;
+    EditBuffer *b = s->b;
+    QEmacsState *qs = s->qs;
+
+    switch (save_ctx->state) {
+    case SAVE_SCAN_EOF:
+        if (b->total_size > 0 && eb_peek_prevc(b, b->total_size) != '\n') {
+            switch (b->require_final_newline) {
+            case +1:
+                eb_putc(b, '\n');
+                break;
+            case -1:
+                qe_grab_keys(qs, save_scan_key, save_ctx);
+                put_error(qs->active_window,
+                          "&Buffer does not end in newline. Add one? (y or n) ");
+                return;
+            default:
+                break;
+            }
+        }
+        save_ctx->state++;
+        FALLTHROUGH;
+    case SAVE_SCAN_WHITESPACE:
+        switch (b->delete_trailing_whitespace) {
+        case +1:
+            do_delete_horizontal_space(s, 3); // DH_FULL
+            break;
+        case -1:
+            qe_grab_keys(qs, save_scan_key, save_ctx);
+            put_error(qs->active_window,
+                      "&Scan buffer and delete trailing whitespace? (y or n) ");
+            return;
+        default:
+            break;
+        }
+        save_ctx->state++;
+        FALLTHROUGH;
+    case SAVE_SCAN_TABS:
+        switch (b->untabify) {
+        case +1:
+            do_untabify(s, 0, b->total_size);
+            break;
+        case -1:
+            qe_grab_keys(qs, save_scan_key, save_ctx);
+            put_error(qs->active_window,
+                      "&Scan buffer and expand tabs to spaces? (y or n) ");
+            return;
+        default:
+            break;
+        }
+        save_ctx->state++;
+        FALLTHROUGH;
+    case SAVE_SCAN_NONE:
+        qe_free(&save_ctx);
+        put_save_message(s, b->filename, eb_save_buffer(b));
+        qe_display(qs);
+        return;
+    }
+}
+#endif /* CONFIG_TINY */
+
 void do_save_buffer(EditState *s)
 {
     if (qe_check_buffer_file(s->b, CBF_SAVE) == CBF_PROMPT)
@@ -9708,6 +9825,16 @@ void do_save_buffer(EditState *s)
         put_status(s, "(No changes need to be saved)");
         return;
     }
+
+#ifndef CONFIG_TINY
+    SaveContext *save_ctx = qe_mallocz(SaveContext);
+    if (save_ctx) {
+        save_ctx->s = s;
+        save_ctx->state = SAVE_SCAN_EOF;
+        save_scan_next(save_ctx);
+        return;
+    }
+#endif
     put_save_message(s, s->b->filename, eb_save_buffer(s->b));
 }
 

--- a/qe.h
+++ b/qe.h
@@ -469,6 +469,11 @@ struct EditBuffer {
     int tab_width;
     int fill_column;
     EOLType eol_type;
+#ifndef CONFIG_TINY
+    int require_final_newline;
+    int delete_trailing_whitespace;
+    int untabify;
+#endif
 
     OWNED EditBuffer *next; /* next editbuffer in qe_state buffer list */
 
@@ -565,6 +570,10 @@ int eb_mmap_buffer(EditBuffer *b, const char *filename);
 void eb_munmap_buffer(EditBuffer *b);
 int eb_write_buffer(EditBuffer *b, int start, int end, const char *filename);
 int eb_save_buffer(EditBuffer *b);
+#ifndef CONFIG_TINY
+void do_delete_horizontal_space(EditState *s, int mode);
+void do_untabify(EditState *s, int p1, int p2);
+#endif
 
 int eb_set_buffer_name(EditBuffer *b, const char *name1);
 void eb_set_filename(EditBuffer *b, const char *filename);
@@ -1106,6 +1115,11 @@ struct QEmacsState {
     int default_tab_width;      /* DEFAULT_TAB_WIDTH */
     int default_fill_column;    /* DEFAULT_FILL_COLUMN */
     EOLType default_eol_type;  /* EOL_UNIX */
+#ifndef CONFIG_TINY
+    int default_require_final_newline;
+    int default_delete_trailing_whitespace;
+    int default_untabify;
+#endif
     int flag_split_window_change_focus;
     int shell_buffer_read_only;
     int shell_mode_auto_interactive;

--- a/variables.c
+++ b/variables.c
@@ -98,6 +98,12 @@ static VarDef var_table[] = {
            "Default value of `tab-width` for buffers that do not override it." )
     S_VAR( "default-fill-column", default_fill_column, VAR_NUMBER, VAR_RW_SAVE,   // XXX: need set_value function
            "Default value of `fill-column` for buffers that do not override it" )
+    S_VAR( "default-require-final-newline", default_require_final_newline, VAR_NUMBER, VAR_RW_SAVE,
+           "Default value of `require-final-newline` for buffers that do not override it.")
+    S_VAR( "default-delete-trailing-whitespace", default_delete_trailing_whitespace, VAR_NUMBER, VAR_RW_SAVE,
+           "Default value of `delete-trailing-whitespace` for buffers that do not override it." )
+    S_VAR( "default-untabify", default_untabify, VAR_NUMBER, VAR_RW_SAVE,
+           "Default value of `untabify` for buffers that do not override it." )
     S_VAR( "backup-inhibited", backup_inhibited, VAR_NUMBER, VAR_RW_SAVE,
            "Set to prevent automatic backups of modified files" )
     S_VAR( "c-label-indent", c_label_indent, VAR_NUMBER, VAR_RW_SAVE,
@@ -119,6 +125,13 @@ static VarDef var_table[] = {
            "Distance between tab stops (for display of tab characters), in columns." )
     B_VAR( "fill-column", fill_column, VAR_NUMBER, VAR_RW,   // XXX: need set_value function
            "Column beyond which automatic line-wrapping should happen." )
+    B_VAR( "require-final-newline", require_final_newline, VAR_NUMBER, VAR_RW,
+           "Set for automatic insertion of trailing new line before saving." )
+    B_VAR( "delete-trailing-whitespace", delete_trailing_whitespace, VAR_NUMBER, VAR_RW,
+           "Set for automatic deletion of trailing whitespace before saving." )
+    B_VAR( "untabify", untabify, VAR_NUMBER, VAR_RW,
+           "Set for automatic expansion of tabs to spaces before saving." )
+
 
     W_VAR_F( "point", offset, VAR_NUMBER, VAR_RW, qe_variable_set_value_offset,    /* should be window-point */
            "Current value of point in this window." )


### PR DESCRIPTION
buffer: add auto-formatting options on save

- `require-final-newline` controls appending trailing newline on save.
- `delete-trailing-whitespace` controls removing trailing whitespace on save.
- `untabify` controls expanding tabs to spaces on save.

modes: refactor initialization functions

* disable `require_final_newline`, `delete_trailing_whitespace` and
  `untabify`  when irrelevant.
* initialize buffer's wrap with default mode value of `wrap`.

Follow-up to: #206